### PR TITLE
Refactor/10 oauth (strategy 패턴 적용)

### DIFF
--- a/server/src/authentication/authentication.controller.ts
+++ b/server/src/authentication/authentication.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Res, HttpStatus, Post, Body } from '@nestjs/common';
 import { Response } from 'express';
-import { AuthenticationService } from './authentication.service';
+import { AuthenticationService } from './service/authentication.service';
 
 @Controller('login')
 export class AuthenticationController {

--- a/server/src/authentication/authentication.controller.ts
+++ b/server/src/authentication/authentication.controller.ts
@@ -9,7 +9,7 @@ export class AuthenticationController {
   @Post()
   async oAuthLogin(
     @Res() res: Response,
-    @Body() oauthDto: { oAuthOrigin: string; code: string },
+    @Body() oauthDto: { targetOAuthOrigin: string; code: string },
   ) {
     const { isRegistered, refreshToken, ...loginResult } =
       await this.authenticationService.loginWithOAuth(oauthDto);

--- a/server/src/authentication/authentication.module.ts
+++ b/server/src/authentication/authentication.module.ts
@@ -4,10 +4,17 @@ import { UserModule } from 'src/user/user.module';
 import { AuthenticationController } from './authentication.controller';
 import { AuthenticationService } from './service/authentication.service';
 import { TokenService } from './service/token.service';
+import { GithubStrategy } from './strategy/github.strategy';
+import { OauthStrategyFactory } from './strategy/oauthStrategy.factory';
 
 @Module({
   imports: [UserModule, JwtModule],
-  providers: [AuthenticationService, TokenService],
+  providers: [
+    AuthenticationService,
+    TokenService,
+    GithubStrategy,
+    OauthStrategyFactory,
+  ],
   exports: [AuthenticationService],
   controllers: [AuthenticationController],
 })

--- a/server/src/authentication/authentication.module.ts
+++ b/server/src/authentication/authentication.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { UserModule } from 'src/user/user.module';
 import { AuthenticationController } from './authentication.controller';
-import { AuthenticationService } from './authentication.service';
+import { AuthenticationService } from './service/authentication.service';
+import { TokenService } from './service/token.service';
 
 @Module({
   imports: [UserModule, JwtModule],
-  providers: [AuthenticationService],
+  providers: [AuthenticationService, TokenService],
   exports: [AuthenticationService],
   controllers: [AuthenticationController],
 })

--- a/server/src/authentication/service/token.service.ts
+++ b/server/src/authentication/service/token.service.ts
@@ -8,6 +8,7 @@ export class TokenService {
     private configService: ConfigService,
     private jwtService: JwtService,
   ) {}
+
   async getAccessToken(userId: string) {
     const tokenSecret = this.configService.get('JWT_ACCESS_TOKEN_SECRET');
     const expirationTime = this.configService.get(
@@ -38,6 +39,7 @@ export class TokenService {
       secret: tokenSecret,
       expiresIn: `${expirationTime}s`,
     });
+
     return token;
   }
 }

--- a/server/src/authentication/service/token.service.ts
+++ b/server/src/authentication/service/token.service.ts
@@ -1,0 +1,43 @@
+import { JwtService } from '@nestjs/jwt';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class TokenService {
+  constructor(
+    private configService: ConfigService,
+    private jwtService: JwtService,
+  ) {}
+  async getAccessToken(userId: string) {
+    const tokenSecret = this.configService.get('JWT_ACCESS_TOKEN_SECRET');
+    const expirationTime = this.configService.get(
+      'JWT_ACCESS_TOKEN_EXPIRATION_TIME',
+    );
+    return this.getToken({ userId, tokenSecret, expirationTime });
+  }
+
+  async getRefreshToken(userId: string) {
+    const tokenSecret = this.configService.get('JWT_REFRESH_TOKEN_SECRET');
+    const expirationTime = this.configService.get(
+      'JWT_REFRESH_TOKEN_EXPIRATION_TIME',
+    );
+    return this.getToken({ userId, tokenSecret, expirationTime });
+  }
+
+  async getToken({
+    userId,
+    tokenSecret,
+    expirationTime,
+  }: {
+    userId: string;
+    tokenSecret: string;
+    expirationTime: number;
+  }) {
+    const payload = { userId };
+    const token = this.jwtService.sign(payload, {
+      secret: tokenSecret,
+      expiresIn: `${expirationTime}s`,
+    });
+    return token;
+  }
+}

--- a/server/src/authentication/strategy/baseOauth.strategy.ts
+++ b/server/src/authentication/strategy/baseOauth.strategy.ts
@@ -8,7 +8,7 @@ export abstract class BaseOAuthStrategy {
     try {
       const response = await axios.get(this.url, {
         headers: {
-          Authorization: `Bearer ${accessToken}ㄴㄴ`,
+          Authorization: `Bearer ${accessToken}`,
         },
       });
       const user = response.data;

--- a/server/src/authentication/strategy/baseOauth.strategy.ts
+++ b/server/src/authentication/strategy/baseOauth.strategy.ts
@@ -1,0 +1,24 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import axios from 'axios';
+import { IAccessTokenInfo } from '../types';
+
+export abstract class BaseOAuthStrategy {
+  protected url: string;
+  public async requestLogin(accessToken: string) {
+    try {
+      const response = await axios.get(this.url, {
+        headers: {
+          Authorization: `Bearer ${accessToken}ㄴㄴ`,
+        },
+      });
+      const user = response.data;
+      return user;
+    } catch (error) {
+      throw new HttpException(
+        'not found user in resource server',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+  public abstract getToken(code: string): Promise<IAccessTokenInfo>;
+}

--- a/server/src/authentication/strategy/github.strategy.ts
+++ b/server/src/authentication/strategy/github.strategy.ts
@@ -1,0 +1,30 @@
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import axios from 'axios';
+import { IAccessTokenInfo } from '../types';
+import { BaseOAuthStrategy } from './baseOauth.strategy';
+
+@Injectable()
+export class GithubStrategy extends BaseOAuthStrategy {
+  constructor() {
+    super();
+    this.url = 'https://api.github.com/user';
+  }
+  public async getToken(code: string) {
+    const githubUrl = 'https://github.com/login/oauth/access_token';
+    const queryConfig = {
+      client_id: process.env['GITHUB_CLIENT_ID'],
+      client_secret: process.env['GITHUB_CLIENT_SECRET'],
+      code,
+    };
+    try {
+      const token = await axios.post<IAccessTokenInfo>(githubUrl, queryConfig, {
+        headers: {
+          Accept: 'application/json',
+        },
+      });
+      return token.data;
+    } catch (error) {
+      throw new HttpException('bad request', HttpStatus.BAD_REQUEST);
+    }
+  }
+}

--- a/server/src/authentication/strategy/oauthStrategy.factory.ts
+++ b/server/src/authentication/strategy/oauthStrategy.factory.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { GithubStrategy } from './github.strategy';
+import { BaseOAuthStrategy } from './baseOauth.strategy';
+
+@Injectable()
+export class OauthStrategyFactory {
+  constructor(private githubStrategy: GithubStrategy) {}
+
+  public build(origin: string): BaseOAuthStrategy {
+    const oAuthMap = {
+      GITHUB: this.githubStrategy,
+    };
+
+    return oAuthMap[origin];
+  }
+}


### PR DESCRIPTION
## 작업내용 요약

- 클라이언트에서 온 OAuthOrigin를 통해서 각각 다른 strategy를 적용(naver , github, kakao 등등)
- strategy 생성을 위해 factory 함수를 작성 

```typescript
// oauthStrategy.factory.ts

import { Injectable } from '@nestjs/common';
import { GithubStrategy } from './github.strategy';
import { BaseOAuthStrategy } from './baseOauth.strategy';

@Injectable()
export class OauthStrategyFactory {
  constructor(private githubStrategy: GithubStrategy) {}
  
  public build(origin: string): BaseOAuthStrategy {
    const oAuthMap = {
      GITHUB: this.githubStrategy,
     // 여기에 NAVER: this.naverStrategy가 추가될 수 있음 
    };

    return oAuthMap[origin];
  }
}



- authentication.service.ts`에서는 팩토리를 통해서 strategy 생성하고 사용한다. 

```typescript
    const strategy = this.strategyFactory.build(targetOAuthOrigin);
    const resourceServerAccessToken = await strategy.getToken(code);
    const resourceServerUser = await strategy.requestLogin(
      resourceServerAccessToken.access_token,
    );
```

## 작업의도

- 현재 client(프론트)에서 쿼리로 oAuthOrigin의 정보를 보내서 어떤 OAuth를 이용하고 있는지 알 수 있었음 
- 네이버, 카카오 등 확장을 고려해서 strategy패턴을 적용 

## 관련이슈

- #10 
