### PR TITLE
Feat/25 productentity (Product 엔티티 구현 및 Get api 구현)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,7 +19,8 @@
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
-        "typeorm": "^0.3.7"
+        "typeorm": "^0.3.7",
+        "typeorm-naming-strategies": "^4.1.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^9.0.0",
@@ -8459,6 +8460,14 @@
         }
       }
     },
+    "node_modules/typeorm-naming-strategies": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-4.1.0.tgz",
+      "integrity": "sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==",
+      "peerDependencies": {
+        "typeorm": "^0.2.0 || ^0.3.0"
+      }
+    },
     "node_modules/typeorm/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -15263,6 +15272,12 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
+    },
+    "typeorm-naming-strategies": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-4.1.0.tgz",
+      "integrity": "sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==",
+      "requires": {}
     },
     "typescript": {
       "version": "4.7.4",

--- a/server/package.json
+++ b/server/package.json
@@ -31,7 +31,8 @@
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
-    "typeorm": "^0.3.7"
+    "typeorm": "^0.3.7",
+    "typeorm-naming-strategies": "^4.1.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -8,6 +8,7 @@ import { RegionModule } from './region/region.module';
 import { AuthenticationModule } from './authentication/authentication.module';
 import { APP_FILTER } from '@nestjs/core';
 import { HttpExceptionFilter } from './core/exception.filter';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { HttpExceptionFilter } from './core/exception.filter';
         database: configService.get('DATABASE_NAME'),
         entities: [__dirname + '/**/entities/*.entity.{js,ts}'],
         synchronize: true,
+        namingStrategy: new SnakeNamingStrategy(),
       }),
     }),
     UserModule,

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,3 +1,4 @@
+import { ProductModule } from './product/product.module';
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -34,6 +35,7 @@ import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
     UserModule,
     RegionModule,
     AuthenticationModule,
+    ProductModule,
   ],
   controllers: [AppController],
   providers: [

--- a/server/src/common/enums.ts
+++ b/server/src/common/enums.ts
@@ -1,0 +1,9 @@
+export enum OAuthOriginEnum {
+  GITHUB = 'github',
+}
+
+export enum SalesStatusEnum {
+  SALE = 'sale',
+  RESERVED = 'reserved',
+  SOLD = 'sold',
+}

--- a/server/src/common/enums/oAuthOrigin.enum.ts
+++ b/server/src/common/enums/oAuthOrigin.enum.ts
@@ -1,3 +1,0 @@
-export enum OAuthOriginEnum {
-  GITHUB = 'github',
-}

--- a/server/src/product/dto/getRegionProducts.dto.ts
+++ b/server/src/product/dto/getRegionProducts.dto.ts
@@ -8,7 +8,7 @@ export class GetRegionProductAPIDto extends PickType(Product, [
   'region',
   'salesStatus',
   'createdAt',
+  'likedUsers',
 ]) {
   thumbnail: string;
-  likeCount: number;
 }

--- a/server/src/product/dto/getRegionProducts.dto.ts
+++ b/server/src/product/dto/getRegionProducts.dto.ts
@@ -1,0 +1,13 @@
+import { Product } from 'src/product/entities/product.entity';
+import { PickType } from '@nestjs/mapped-types';
+
+export class GetRegionProductsDto extends PickType(Product, [
+  'id',
+  'name',
+  'price',
+  'region',
+  'salesStatus',
+  'createdAt',
+]) {
+  thumbnail: string;
+}

--- a/server/src/product/dto/getRegionProducts.dto.ts
+++ b/server/src/product/dto/getRegionProducts.dto.ts
@@ -10,4 +10,5 @@ export class GetRegionProductAPIDto extends PickType(Product, [
   'createdAt',
 ]) {
   thumbnail: string;
+  likeCount: number;
 }

--- a/server/src/product/dto/getRegionProducts.dto.ts
+++ b/server/src/product/dto/getRegionProducts.dto.ts
@@ -1,7 +1,7 @@
 import { Product } from 'src/product/entities/product.entity';
 import { PickType } from '@nestjs/mapped-types';
 
-export class GetRegionProductsDto extends PickType(Product, [
+export class GetRegionProductAPIDto extends PickType(Product, [
   'id',
   'name',
   'price',

--- a/server/src/product/entities/category.entity.ts
+++ b/server/src/product/entities/category.entity.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Product } from './product.entity';
+
+@Entity()
+export class Category {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 20 })
+  name: string;
+
+  @OneToMany(() => Product, (product) => product.category)
+  products: Product[];
+}

--- a/server/src/product/entities/like.entity.ts
+++ b/server/src/product/entities/like.entity.ts
@@ -1,0 +1,20 @@
+import { Product } from 'src/product/entities/product.entity';
+import { User } from 'src/user/entities/user.entity';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+@Entity()
+export class Like {
+  @Column({ type: 'int', primary: true })
+  productId: number;
+
+  @Column({ type: 'int', primary: true })
+  userId: number;
+
+  @ManyToOne(() => Product, (product) => product.likedUsers)
+  @JoinColumn({ name: 'product_id' })
+  product: Product;
+
+  @ManyToOne(() => User, (user) => user.likedProducts)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+}

--- a/server/src/product/entities/product.entity.ts
+++ b/server/src/product/entities/product.entity.ts
@@ -1,0 +1,64 @@
+import { SalesStatusEnum } from './../../common/enums';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Category } from './category.entity';
+import { User } from 'src/user/entities/user.entity';
+import { Region } from 'src/region/entities/region.entity';
+
+@Entity()
+export class Product {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 45 })
+  name: string;
+
+  @Column({ type: 'json' })
+  thumbnails: string[];
+
+  @Column({ type: 'decimal' })
+  price: number;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @Column({ type: 'int' })
+  view: number;
+
+  @Column({ type: 'enum', enum: SalesStatusEnum })
+  salesStatus: string;
+
+  @Column({ type: 'int' })
+  categoryId: number;
+
+  @Column({ type: 'int' })
+  sellerId: number;
+
+  @Column({ type: 'int' })
+  regionId: number;
+
+  @ManyToOne(() => Category, (category) => category.products)
+  @JoinColumn({ name: 'category_id' })
+  category: Category;
+
+  @ManyToOne(() => User, (user) => user.products)
+  @JoinColumn({ name: 'seller_id' })
+  seller: User;
+
+  @ManyToOne(() => Region, (region) => region.products)
+  @JoinColumn({ name: 'region_id' })
+  region: Region;
+}

--- a/server/src/product/entities/product.entity.ts
+++ b/server/src/product/entities/product.entity.ts
@@ -5,12 +5,14 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { Category } from './category.entity';
 import { User } from 'src/user/entities/user.entity';
 import { Region } from 'src/region/entities/region.entity';
+import { Like } from './like.entity';
 
 @Entity()
 export class Product {
@@ -61,4 +63,7 @@ export class Product {
   @ManyToOne(() => Region, (region) => region.products)
   @JoinColumn({ name: 'region_id' })
   region: Region;
+
+  @OneToMany(() => Like, (like) => like.product)
+  likedUsers: Like[];
 }

--- a/server/src/product/product.controller.ts
+++ b/server/src/product/product.controller.ts
@@ -31,8 +31,8 @@ export class ProductController {
         region,
         salesStatus,
         createdAt,
+        likedUsers,
         thumbnail: thumbnails[0],
-        likeCount: likedUsers.length,
       };
     });
     return res

--- a/server/src/product/product.controller.ts
+++ b/server/src/product/product.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Query, Res, HttpStatus } from '@nestjs/common';
 import { Response } from 'express';
+import { GetRegionProductAPIDto } from './dto/getRegionProducts.dto';
 import { ProductService } from './product.service';
 
 @Controller('products')
@@ -12,6 +13,21 @@ export class ProductController {
     @Query('region-id') regionId: number,
   ) {
     const products = await this.productService.getRegionProducts(regionId);
-    return res.status(HttpStatus.OK).json({ ok: true, products });
+    const parsedProducts: GetRegionProductAPIDto[] = products.map((product) => {
+      const { id, name, price, region, salesStatus, createdAt, thumbnails } =
+        product;
+      return {
+        id,
+        name,
+        price,
+        region,
+        salesStatus,
+        createdAt,
+        thumbnail: thumbnails[0],
+      };
+    });
+    return res
+      .status(HttpStatus.OK)
+      .json({ ok: true, products: parsedProducts });
   }
 }

--- a/server/src/product/product.controller.ts
+++ b/server/src/product/product.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Query, Res, HttpStatus } from '@nestjs/common';
+import { Response } from 'express';
+import { ProductService } from './product.service';
+
+@Controller('products')
+export class ProductController {
+  constructor(private readonly productService: ProductService) {}
+
+  @Get()
+  async getRegionProducts(
+    @Res() res: Response,
+    @Query('region-id') regionId: number,
+  ) {
+    const products = await this.productService.getRegionProducts(regionId);
+    return res.status(HttpStatus.OK).json({ ok: true, products });
+  }
+}

--- a/server/src/product/product.controller.ts
+++ b/server/src/product/product.controller.ts
@@ -14,8 +14,16 @@ export class ProductController {
   ) {
     const products = await this.productService.getRegionProducts(regionId);
     const parsedProducts: GetRegionProductAPIDto[] = products.map((product) => {
-      const { id, name, price, region, salesStatus, createdAt, thumbnails } =
-        product;
+      const {
+        id,
+        name,
+        price,
+        region,
+        salesStatus,
+        createdAt,
+        thumbnails,
+        likedUsers,
+      } = product;
       return {
         id,
         name,
@@ -24,6 +32,7 @@ export class ProductController {
         salesStatus,
         createdAt,
         thumbnail: thumbnails[0],
+        likeCount: likedUsers.length,
       };
     });
     return res

--- a/server/src/product/product.module.ts
+++ b/server/src/product/product.module.ts
@@ -1,0 +1,10 @@
+import { ProductController } from './product.controller';
+import { Module } from '@nestjs/common';
+import { ProductService } from './product.service';
+import { ProductRepository } from './repository/product.repository';
+
+@Module({
+  controllers: [ProductController],
+  providers: [ProductService, ProductRepository],
+})
+export class ProductModule {}

--- a/server/src/product/product.service.ts
+++ b/server/src/product/product.service.ts
@@ -1,0 +1,12 @@
+import { ProductRepository } from './repository/product.repository';
+import { Injectable } from '@nestjs/common';
+import { Product } from './entities/product.entity';
+
+@Injectable()
+export class ProductService {
+  constructor(private readonly productRepository: ProductRepository) {}
+
+  getRegionProducts(regionId: number): Promise<Product[]> {
+    return this.productRepository.findProductsByRegion(regionId);
+  }
+}

--- a/server/src/product/repository/product.repository.ts
+++ b/server/src/product/repository/product.repository.ts
@@ -13,7 +13,7 @@ export class ProductRepository {
   public async findProductsByRegion(regionId: number): Promise<Product[]> {
     return this.repository.find({
       where: { regionId },
-      relations: { region: true },
+      relations: ['region', 'likedUsers'],
     });
   }
 }

--- a/server/src/product/repository/product.repository.ts
+++ b/server/src/product/repository/product.repository.ts
@@ -1,0 +1,19 @@
+import { DataSource, Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { Product } from '../entities/product.entity';
+
+@Injectable()
+export class ProductRepository {
+  private repository: Repository<Product>;
+
+  constructor(private dataSource: DataSource) {
+    this.repository = this.dataSource.getRepository(Product);
+  }
+
+  public async findProductsByRegion(regionId: number): Promise<Product[]> {
+    return this.repository.find({
+      where: { regionId },
+      relations: { region: true },
+    });
+  }
+}

--- a/server/src/region/entities/region.entity.ts
+++ b/server/src/region/entities/region.entity.ts
@@ -1,3 +1,4 @@
+import { Product } from 'src/product/entities/product.entity';
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { UserRegion } from './userRegion.entity';
 
@@ -11,4 +12,7 @@ export class Region {
 
   @OneToMany(() => UserRegion, (userRegion) => userRegion.region)
   users: UserRegion[];
+
+  @OneToMany(() => Product, (product) => product.region)
+  products: Product[];
 }

--- a/server/src/region/entities/userRegion.entity.ts
+++ b/server/src/region/entities/userRegion.entity.ts
@@ -20,10 +20,10 @@ export class UserRegion {
   userId: number;
 
   @ManyToOne(() => Region, (region) => region.users)
-  @JoinColumn({ name: 'regionId' })
+  @JoinColumn({ name: 'region_id' })
   region: Region;
 
   @ManyToOne(() => User, (user) => user.regions)
-  @JoinColumn({ name: 'userId' })
+  @JoinColumn({ name: 'user_id' })
   user: User;
 }

--- a/server/src/region/repository/region.repository.ts
+++ b/server/src/region/repository/region.repository.ts
@@ -22,4 +22,15 @@ export class RegionRepository {
       },
     });
   }
+
+  public async findOneRegionProducts(regionId: number): Promise<Region[]> {
+    return this.repository.find({
+      where: {
+        id: regionId,
+      },
+      relations: {
+        products: true,
+      },
+    });
+  }
 }

--- a/server/src/region/repository/region.repository.ts
+++ b/server/src/region/repository/region.repository.ts
@@ -22,15 +22,4 @@ export class RegionRepository {
       },
     });
   }
-
-  public async findOneRegionProducts(regionId: number): Promise<Region[]> {
-    return this.repository.find({
-      where: {
-        id: regionId,
-      },
-      relations: {
-        products: true,
-      },
-    });
-  }
 }

--- a/server/src/user/entities/user.entity.ts
+++ b/server/src/user/entities/user.entity.ts
@@ -1,4 +1,5 @@
-import { OAuthOriginEnum } from 'src/common/enums/oAuthOrigin.enum';
+import { Product } from './../../product/entities/product.entity';
+import { OAuthOriginEnum } from 'src/common/enums';
 import { UserRegion } from 'src/region/entities/userRegion.entity';
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
@@ -18,4 +19,7 @@ export class User {
 
   @OneToMany(() => UserRegion, (userRegion) => userRegion.user)
   regions: UserRegion[];
+
+  @OneToMany(() => Product, (product) => product.seller)
+  products: Product[];
 }

--- a/server/src/user/entities/user.entity.ts
+++ b/server/src/user/entities/user.entity.ts
@@ -2,6 +2,7 @@ import { Product } from './../../product/entities/product.entity';
 import { OAuthOriginEnum } from 'src/common/enums';
 import { UserRegion } from 'src/region/entities/userRegion.entity';
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Like } from 'src/product/entities/like.entity';
 
 @Entity()
 export class User {
@@ -22,4 +23,7 @@ export class User {
 
   @OneToMany(() => Product, (product) => product.seller)
   products: Product[];
+
+  @OneToMany(() => Like, (like) => like.user)
+  likedProducts: Like[];
 }


### PR DESCRIPTION
## 작업내용 요약

- product 엔티티와 chat을 제외한 모든 관계된 entity 추가
- 지역에 맞는 product를 가져오는 API 구현
 
## 작업의도

- 클라이언트에서 데이터를 정제하여 사용할지, 서버에서 정제하여 넘겨줄지 고민했습니다.
- 불필요한 데이터를 넘기는것을 방지하기 위해 서버에서 데이터를 정제했는데 만약 서버에 부하가 걸릴 것을 우려한다면 클라이언트에서 처리하는 것이 나을수 있습니다.
- 이후 쿼리로 필터하는 기능을 추가구현해야합니다.
- request, response Dto를 서버에 뒀는데, client에서도 당연히 같이 사용될 것이므로 공유할 수 있는 방법을 찾아야합니다.
## 관련이슈

- #25 
