### PR TITLE
Feat/30 reactquery (로그인 및 회원가입 로직에 리액트 쿼리 적용)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@craco/craco": "^7.0.0-alpha.3",
         "@tanstack/react-query": "^4.1.3",
+        "@tanstack/react-query-devtools": "^4.2.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3485,6 +3486,21 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.1.1.tgz",
+      "integrity": "sha512-IdmEekEYxQsoLOR0XQyw3jD1GujBpRRYaGJYQUw1eOT1eUugWxdc7jomh1VQ1EKHcdwDLpLaCz/8y4KraU4T9A==",
+      "dependencies": {
+        "remove-accents": "0.4.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kentcdodds"
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.2.0.tgz",
@@ -3519,6 +3535,25 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.2.1.tgz",
+      "integrity": "sha512-k7Ch3qvs8U74aRMMRvNisxcxZFTzk8FDdvpQKXxSZ8fsD4ZwpM0MoUSqKsCXbfTvUI7MJiGxavy1YlvImPNO+Q==",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.0.0-alpha.82",
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^4.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -14563,6 +14598,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -19583,6 +19623,14 @@
         "loader-utils": "^2.0.0"
       }
     },
+    "@tanstack/match-sorter-utils": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.1.1.tgz",
+      "integrity": "sha512-IdmEekEYxQsoLOR0XQyw3jD1GujBpRRYaGJYQUw1eOT1eUugWxdc7jomh1VQ1EKHcdwDLpLaCz/8y4KraU4T9A==",
+      "requires": {
+        "remove-accents": "0.4.2"
+      }
+    },
     "@tanstack/query-core": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.2.0.tgz",
@@ -19594,6 +19642,16 @@
       "integrity": "sha512-BHI/dV3LOuVOZAaifM6u680Wi5rmiHu4aD3WkvrQT/9fYhHDhTzMdJO8l2Xh0UR7JhM8e9O3f89SJhD3T8Ejgw==",
       "requires": {
         "@tanstack/query-core": "^4.0.0-beta.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
+    "@tanstack/react-query-devtools": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.2.1.tgz",
+      "integrity": "sha512-k7Ch3qvs8U74aRMMRvNisxcxZFTzk8FDdvpQKXxSZ8fsD4ZwpM0MoUSqKsCXbfTvUI7MJiGxavy1YlvImPNO+Q==",
+      "requires": {
+        "@tanstack/match-sorter-utils": "^8.0.0-alpha.82",
         "@types/use-sync-external-store": "^0.0.3",
         "use-sync-external-store": "^1.2.0"
       }
@@ -27500,6 +27558,11 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
+    },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
     "renderkid": {
       "version": "3.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@craco/craco": "^7.0.0-alpha.3",
     "@tanstack/react-query": "^4.1.3",
+    "@tanstack/react-query-devtools": "^4.2.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,10 @@ import styled from 'styled-components';
 import portalUtil from '@utils/portal';
 import { useRef, useEffect } from 'react';
 import mixin from '@style/mixin';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+const queryClient = new QueryClient();
 
 export default function App() {
   const displayRef = useRef<HTMLDivElement | null>(null);
@@ -14,12 +18,16 @@ export default function App() {
   }, []);
 
   return (
-    <AppWrapper>
-      <Display ref={displayRef}>
-        <GlobalStyle />
-        <Routes />
-      </Display>
-    </AppWrapper>
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={false} />
+
+      <AppWrapper>
+        <Display ref={displayRef}>
+          <GlobalStyle />
+          <Routes />
+        </Display>
+      </AppWrapper>
+    </QueryClientProvider>
   );
 }
 

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -1,4 +1,5 @@
-import { CheckDuplicatedResponseDto } from '@customTypes/user';
+import { IOAuthUserInfo } from '@customTypes/auth';
+import { CheckDuplicatedResponseDto, LoginAPIResponseDto } from '@customTypes/user';
 import { makeQueryString } from '@utils/queryParser';
 import axios from 'axios';
 
@@ -9,4 +10,26 @@ export const checkDuplicatedUser = async (nickname: string) => {
   const queryString = makeQueryString(queryConfig);
   const response = await axios.get<CheckDuplicatedResponseDto>(`/user${queryString}`);
   return response.data.data;
+};
+
+interface SignUpRequestDto {
+  name: string;
+  regionId: number;
+  oAuthInfo: IOAuthUserInfo;
+}
+
+export const requestSignUp = async ({ name, regionId, oAuthInfo }: SignUpRequestDto) => {
+  await axios.post('/user/sign-up', {
+    name,
+    regionId,
+    ...oAuthInfo,
+  });
+};
+
+export const requestLogin = async (code: string, oAuthOrigin: string) => {
+  const { data: loginResponse } = await axios.post<LoginAPIResponseDto>('/login', {
+    code,
+    oAuthOrigin,
+  });
+  return loginResponse;
 };

--- a/client/src/hooks/useLogin.tsx
+++ b/client/src/hooks/useLogin.tsx
@@ -3,8 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { LoginAPIResponseDto } from '@customTypes/user';
 import { useQuery } from '@tanstack/react-query';
 import { requestLogin } from '@apis/user';
-import LoadingIndicator from '@components/common/LoadingIndicator';
-import React from 'react';
 
 export default function useLogin() {
   const navigate = useNavigate();
@@ -14,12 +12,11 @@ export default function useLogin() {
   };
 
   const login = async (code: string, oAuthOrigin: string) => {
-    const { data, error, isLoading } = useQuery<LoginAPIResponseDto>(['user'], () =>
+    const { data, error } = useQuery<LoginAPIResponseDto>(['user'], () =>
       requestLogin(code, oAuthOrigin),
     );
-    if (!data || isLoading) {
-      return <LoadingIndicator />;
-    }
+
+    if (!data) return;
 
     if (data.isRegistered) {
       setAccessTokenOnHeader(data.accessToken);
@@ -33,8 +30,6 @@ export default function useLogin() {
     if (error) {
       navigate('/error');
     }
-
-    return <LoadingIndicator />;
   };
 
   return { login };

--- a/client/src/hooks/useLogin.tsx
+++ b/client/src/hooks/useLogin.tsx
@@ -1,6 +1,10 @@
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { LoginAPIResponseDto } from '@customTypes/user';
+import { useQuery } from '@tanstack/react-query';
+import { requestLogin } from '@apis/user';
+import LoadingIndicator from '@components/common/LoadingIndicator';
+import React from 'react';
 
 export default function useLogin() {
   const navigate = useNavigate();
@@ -9,22 +13,28 @@ export default function useLogin() {
     axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
   };
 
-  const login = async (code: string, targetOAuthOrigin: string) => {
-    try {
-      const { data: loginResponse } = await axios.post<LoginAPIResponseDto>('/login', {
-        code,
-        targetOAuthOrigin,
-      });
+  const login = async (code: string, oAuthOrigin: string) => {
+    const { data, error, isLoading } = useQuery<LoginAPIResponseDto>(['user'], () =>
+      requestLogin(code, oAuthOrigin),
+    );
+    if (!data || isLoading) {
+      return <LoadingIndicator />;
+    }
 
-      if (loginResponse.isRegistered) {
-        setAccessTokenOnHeader(loginResponse.accessToken);
-        navigate('/');
-      } else {
-        navigate('/signUp', { state: { ...loginResponse.oAuthInfo } });
-      }
-    } catch (e) {
+    if (data.isRegistered) {
+      setAccessTokenOnHeader(data.accessToken);
+      navigate('/');
+    }
+
+    if (!data.isRegistered) {
+      navigate('/signUp', { state: { ...data.oAuthInfo } });
+    }
+
+    if (error) {
       navigate('/error');
     }
+
+    return <LoadingIndicator />;
   };
 
   return { login };

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import { redirectToOAuthUrl } from '@utils/oAuth';
-import NavigationBar from '@components/common/NavigationBar';
 import Button from '@components/common/Button';
 import mixin from '@style/mixin';
 

--- a/client/src/pages/OAuthRedirectPage.tsx
+++ b/client/src/pages/OAuthRedirectPage.tsx
@@ -1,3 +1,4 @@
+import LoadingIndicator from '@components/common/LoadingIndicator';
 import useLogin from '@hooks/useLogin';
 import { getQueryValue } from '@utils/queryParser';
 
@@ -9,4 +10,6 @@ export default function OAuthRedirectPage() {
   }
   const { login } = useLogin();
   login(code, oAuthOrigin);
+
+  return <LoadingIndicator />;
 }

--- a/client/src/pages/OAuthRedirectPage.tsx
+++ b/client/src/pages/OAuthRedirectPage.tsx
@@ -1,21 +1,12 @@
-import { useEffect } from 'react';
 import useLogin from '@hooks/useLogin';
 import { getQueryValue } from '@utils/queryParser';
-import LoadingIndicator from '@components/common/LoadingIndicator';
 
 export default function OAuthRedirectPage() {
-  const { login } = useLogin();
-
   const code = getQueryValue('code');
   const oAuthOrigin = getQueryValue('origin');
-
   if (!code || !oAuthOrigin) {
     throw new Error('유효하지 않은 리다이렉션입니다');
   }
-
-  useEffect(() => {
-    login(code, oAuthOrigin);
-  }, []);
-
-  return <LoadingIndicator />;
+  const { login } = useLogin();
+  login(code, oAuthOrigin);
 }

--- a/server/src/authentication/authentication.controller.ts
+++ b/server/src/authentication/authentication.controller.ts
@@ -9,7 +9,7 @@ export class AuthenticationController {
   @Post()
   async oAuthLogin(
     @Res() res: Response,
-    @Body() oauthDto: { targetOAuthOrigin: string; code: string },
+    @Body() oauthDto: { oAuthOrigin: string; code: string },
   ) {
     const { isRegistered, refreshToken, ...loginResult } =
       await this.authenticationService.loginWithOAuth(oauthDto);

--- a/server/src/authentication/decorators/use.auth.guard.decorator.ts
+++ b/server/src/authentication/decorators/use.auth.guard.decorator.ts
@@ -1,0 +1,6 @@
+import { applyDecorators, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '../guards/auth.guard';
+
+export function UseAuthGuard() {
+  return applyDecorators(UseGuards(AuthGuard));
+}

--- a/server/src/authentication/guards/auth.guard.ts
+++ b/server/src/authentication/guards/auth.guard.ts
@@ -1,0 +1,34 @@
+import { Request } from 'express';
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { AuthenticationService } from '../service/authentication.service';
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(
+    @Inject(AuthenticationService)
+    private readonly authService: AuthenticationService,
+  ) {}
+
+  async canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest<Request>();
+    const authorizationToken = request.headers.authorization;
+    if (!authorizationToken) {
+      throw new HttpException('token이 없습니다.', HttpStatus.UNAUTHORIZED);
+    }
+
+    const accessToken = request.headers.authorization
+      .split('Bearer ')
+      .join('')
+      .trim();
+
+    const user = await this.authService.validateAccessToken(accessToken);
+    request['user'] = user;
+    return true;
+  }
+}

--- a/server/src/authentication/service/authentication.service.ts
+++ b/server/src/authentication/service/authentication.service.ts
@@ -34,9 +34,9 @@ export class AuthenticationService {
     };
 
     if (clientUser) {
-      const { oAuthId } = oAuthInfo;
-      const accessToken = await this.tokenService.getAccessToken(oAuthId);
-      const refreshToken = await this.tokenService.getRefreshToken(oAuthId);
+      const { id } = clientUser;
+      const accessToken = await this.tokenService.getAccessToken(id);
+      const refreshToken = await this.tokenService.getRefreshToken(id);
       return {
         isRegistered: true,
         user: clientUser,

--- a/server/src/authentication/service/authentication.service.ts
+++ b/server/src/authentication/service/authentication.service.ts
@@ -12,13 +12,13 @@ export class AuthenticationService {
     private readonly strategyFactory: OauthStrategyFactory,
   ) {}
   async loginWithOAuth({
-    targetOAuthOrigin,
+    oAuthOrigin,
     code,
   }: {
-    targetOAuthOrigin: string;
+    oAuthOrigin: string;
     code: string;
   }) {
-    const strategy = this.strategyFactory.build(targetOAuthOrigin);
+    const strategy = this.strategyFactory.build(oAuthOrigin);
     const resourceServerAccessToken = await strategy.getToken(code);
     const resourceServerUser = await strategy.requestLogin(
       resourceServerAccessToken.access_token,
@@ -29,7 +29,7 @@ export class AuthenticationService {
     );
 
     const oAuthInfo = {
-      targetOAuthOrigin,
+      oAuthOrigin,
       oAuthId: resourceServerUser.id,
     };
 

--- a/server/src/authentication/service/authentication.service.ts
+++ b/server/src/authentication/service/authentication.service.ts
@@ -1,5 +1,5 @@
 import { OauthStrategyFactory } from './../strategy/oauthStrategy.factory';
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 
 import { UserService } from 'src/user/user.service';
 import { TokenService } from './token.service';
@@ -50,5 +50,15 @@ export class AuthenticationService {
       isRegistered: false,
       oAuthInfo,
     };
+  }
+
+  async validateAccessToken(accessToken: string) {
+    try {
+      const userId = this.tokenService.verify(accessToken);
+      const user = await this.userService.getOneByUserId(userId);
+      return user;
+    } catch (error) {
+      throw new HttpException('유효하지 않은 토큰', HttpStatus.UNAUTHORIZED);
+    }
   }
 }

--- a/server/src/authentication/service/token.service.ts
+++ b/server/src/authentication/service/token.service.ts
@@ -9,7 +9,7 @@ export class TokenService {
     private jwtService: JwtService,
   ) {}
 
-  async getAccessToken(userId: string) {
+  async getAccessToken(userId: number) {
     const tokenSecret = this.configService.get('JWT_ACCESS_TOKEN_SECRET');
     const expirationTime = this.configService.get(
       'JWT_ACCESS_TOKEN_EXPIRATION_TIME',
@@ -17,7 +17,7 @@ export class TokenService {
     return this.getToken({ userId, tokenSecret, expirationTime });
   }
 
-  async getRefreshToken(userId: string) {
+  async getRefreshToken(userId: number) {
     const tokenSecret = this.configService.get('JWT_REFRESH_TOKEN_SECRET');
     const expirationTime = this.configService.get(
       'JWT_REFRESH_TOKEN_EXPIRATION_TIME',
@@ -30,7 +30,7 @@ export class TokenService {
     tokenSecret,
     expirationTime,
   }: {
-    userId: string;
+    userId: number;
     tokenSecret: string;
     expirationTime: number;
   }) {

--- a/server/src/authentication/service/token.service.ts
+++ b/server/src/authentication/service/token.service.ts
@@ -42,4 +42,13 @@ export class TokenService {
 
     return token;
   }
+
+  verify(accessToken: string) {
+    const tokenSecret = this.configService.get('JWT_ACCESS_TOKEN_SECRET');
+
+    const { userId } = this.jwtService.verify<{ userId: string }>(accessToken, {
+      secret: tokenSecret,
+    });
+    return userId;
+  }
 }

--- a/server/src/product/product.controller.ts
+++ b/server/src/product/product.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Query, Res, HttpStatus } from '@nestjs/common';
 import { Response } from 'express';
+import { UseAuthGuard } from 'src/authentication/decorators/use.auth.guard.decorator';
 import { GetRegionProductAPIDto } from './dto/getRegionProducts.dto';
 import { ProductService } from './product.service';
 
@@ -8,6 +9,7 @@ export class ProductController {
   constructor(private readonly productService: ProductService) {}
 
   @Get()
+  @UseAuthGuard()
   async getRegionProducts(
     @Res() res: Response,
     @Query('region-id') regionId: number,

--- a/server/src/product/product.module.ts
+++ b/server/src/product/product.module.ts
@@ -1,9 +1,11 @@
+import { AuthenticationModule } from './../authentication/authentication.module';
 import { ProductController } from './product.controller';
 import { Module } from '@nestjs/common';
 import { ProductService } from './product.service';
 import { ProductRepository } from './repository/product.repository';
 
 @Module({
+  imports: [AuthenticationModule],
   controllers: [ProductController],
   providers: [ProductService, ProductRepository],
 })

--- a/server/src/user/entities/user.entity.ts
+++ b/server/src/user/entities/user.entity.ts
@@ -9,13 +9,13 @@ export class User {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ type: 'varchar', length: 20 })
+  @Column({ type: 'varchar', length: 20, nullable: false, unique: true })
   name: string;
 
-  @Column({ type: 'enum', enum: OAuthOriginEnum })
+  @Column({ type: 'enum', enum: OAuthOriginEnum, nullable: false })
   oAuthOrigin: string;
 
-  @Column({ type: 'varchar' })
+  @Column({ type: 'varchar', nullable: false })
   oAuthId: string;
 
   @OneToMany(() => UserRegion, (userRegion) => userRegion.user)

--- a/server/src/user/repository/user.repository.ts
+++ b/server/src/user/repository/user.repository.ts
@@ -29,4 +29,11 @@ export class UserRepository {
       select: ['id', 'name', 'regions'],
     });
   }
+
+  public async findOneByUserId(id: number): Promise<UserResponseDto> {
+    return this.repository.findOne({
+      where: { id },
+      select: ['id', 'name', 'regions'],
+    });
+  }
 }

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -20,8 +20,8 @@ export class UserController {
     @Res() res: Response,
     @Body() createUserDto: CreateUserRequestDto,
   ) {
-    const userId = await this.userService.create(createUserDto);
-    return res.status(HttpStatus.CREATED).json({ ok: true, userId });
+    await this.userService.create(createUserDto);
+    res.status(HttpStatus.CREATED).json({ ok: true });
   }
 
   @Get('')

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -54,6 +54,17 @@ export class UserService {
     }
   }
 
+  async getOneByUserId(id: string) {
+    try {
+      return await this.userRepository.findOneByUserId(Number(id));
+    } catch (e) {
+      throw new HttpException(
+        '존재하지 않는 유저입니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+  }
+
   async checkDuplicatedUserByNickname(name: string) {
     const user = await this.userRepository.findOneByName(name);
 

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import { UserRegionRepository } from 'src/region/repository/userRegion.repository';
 import { CreateUserRequestDto } from './dto/createUserRequset.dto';
 import { UserRepository } from './repository/user.repository';
@@ -12,22 +12,49 @@ export class UserService {
 
   async create(createUserDto: CreateUserRequestDto) {
     const { name, oAuthOrigin, oAuthId, regionId } = createUserDto;
-    const newUser = await this.userRepository.create({
-      name,
-      oAuthOrigin,
-      oAuthId,
-    });
-
-    await this.regionRepository.create({
-      userId: newUser.id,
-      regionId,
-    });
-    return newUser;
+    try {
+      const newUser = await this.userRepository.create({
+        name,
+        oAuthOrigin,
+        oAuthId,
+      });
+      await this.regionRepository.create({
+        userId: newUser.id,
+        regionId,
+      });
+    } catch (error) {
+      console.log(error);
+      switch (error.errno) {
+        case 1062:
+          throw new HttpException(
+            '중복된 유저 이름입니다.',
+            HttpStatus.CONFLICT,
+          );
+        case 1452:
+          throw new HttpException(
+            '존재하지 않는 동네입니다.',
+            HttpStatus.NOT_FOUND,
+          );
+        default:
+          throw new HttpException(
+            '회원가입에 실패했습니다.',
+            HttpStatus.BAD_REQUEST,
+          );
+      }
+    }
   }
 
   async getOneByOAuthId(id: string) {
-    return await this.userRepository.findOneByOAuthId(id);
+    try {
+      return await this.userRepository.findOneByOAuthId(id);
+    } catch (e) {
+      throw new HttpException(
+        '존재하지 않는 유저입니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
   }
+
   async checkDuplicatedUserByNickname(name: string) {
     const user = await this.userRepository.findOneByName(name);
 

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -23,7 +23,6 @@ export class UserService {
         regionId,
       });
     } catch (error) {
-      console.log(error);
       switch (error.errno) {
         case 1062:
           throw new HttpException(

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -55,14 +55,14 @@ export class UserService {
   }
 
   async getOneByUserId(id: string) {
-    try {
-      return await this.userRepository.findOneByUserId(Number(id));
-    } catch (e) {
+    const user = await this.userRepository.findOneByUserId(Number(id));
+    if (!user) {
       throw new HttpException(
         '존재하지 않는 유저입니다.',
         HttpStatus.NOT_FOUND,
       );
     }
+    return user;
   }
 
   async checkDuplicatedUserByNickname(name: string) {


### PR DESCRIPTION
## 작업내용 요약

- 로그인 및 회원가입 로직 개선.
- 회원가입시 자동으로 로그인 되게 구현
- 발급받은 access-token(우리 앱 전용)으로 유저 식별 후 API 응답하도록 구현

## 작업의도

- 리액트 쿼리는 현재 서버 데이터를 cache하는데 사용하고 있진 않음
- 이전 프로젝트에서 라이브러리를 사용하지 않고 직접 만들었던 useAxios 등의 함수와 비슷한 용도로 사용
- 이번 앱은 중고 거래. 즉 실시간으로 다른 유저에의해 상품이 추가되고, 수정되기 때문에 클라이언트 단의 상태보다 서버의 상태를 잘 관리하는 것이 중요
- 어떤 데이터를 캐시할지, 클라이언트가 갖고 있는 서버의 상태는 언제까지 믿을 수 있는지 등을 잘 분석하여 사용하는 것이 필요


## 관련이슈

- #30 
