### PR TITLE
Feat/31 post 페이지 작성 

### DIFF
--- a/client/src/assets/icons/CheckIcon.tsx
+++ b/client/src/assets/icons/CheckIcon.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+function CheckIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 24 24">
+      <path
+        stroke="black"
+        strokeWidth="2px"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21 6L8.625 18 3 12.546"
+      />
+    </svg>
+  );
+}
+
+export default CheckIcon;

--- a/client/src/assets/icons/ImageIcon.tsx
+++ b/client/src/assets/icons/ImageIcon.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+function ImageIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M19 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V5a2 2 0 00-2-2z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M8.5 10a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM21 15l-5-5L5 21"
+      />
+    </svg>
+  );
+}
+
+export default ImageIcon;

--- a/client/src/assets/icons/XIcon.tsx
+++ b/client/src/assets/icons/XIcon.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function XIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M18 6L6 18M6 6l12 12" />
+    </svg>
+  );
+}
+
+export default XIcon;

--- a/client/src/components/MainPageNavigationBar/index.tsx
+++ b/client/src/components/MainPageNavigationBar/index.tsx
@@ -11,7 +11,7 @@ export default function MainPageNavigationBar() {
   const navigate = useNavigate();
 
   return (
-    <Contianer>
+    <Container>
       <IconButton left="1rem" onClick={() => navigate('/error')}>
         <CategoryIcon />
       </IconButton>
@@ -22,11 +22,11 @@ export default function MainPageNavigationBar() {
       <IconButton right="1rem" onClick={() => navigate('/error')}>
         <MenuIcon />
       </IconButton>
-    </Contianer>
+    </Container>
   );
 }
 
-const Contianer = styled.div`
+const Container = styled.div`
   position: absolute;
   top: 0;
   ${mixin.flexMixin({ justify: 'center', align: 'center' })}

--- a/client/src/components/Post/CategorySelector.tsx
+++ b/client/src/components/Post/CategorySelector.tsx
@@ -11,8 +11,8 @@ export default function CategorySelector() {
       <Text size="xSmall">(필수) 카테고리를 선택해주세요</Text>
       <CategoriesContainer>
         {categories.map((category) => (
-          <ItemWrapper>
-            <Text size="small">{category}</Text>
+          <ItemWrapper isActive={category === '여성패션 잡화'}>
+            <Text>{category}</Text>
           </ItemWrapper>
         ))}
       </CategoriesContainer>
@@ -21,20 +21,27 @@ export default function CategorySelector() {
 }
 
 const Container = styled.div`
-  padding: 24px 0;
+  padding-bottom: 24px;
+
   border-bottom: 1px solid ${colors.grey3};
   color: ${colors.grey1};
   width: 100%;
   overflow-x: hidden;
   ${Text} {
-    color: ${colors.grey1};
+    color: ${colors.grey2};
   }
 `;
-const ItemWrapper = styled.div`
+const ItemWrapper = styled.div<{ isActive?: boolean }>`
   padding: 4px 16px;
   border: 1px solid ${colors.grey3};
   border-radius: 999px;
   white-space: nowrap;
+
+  background-color: ${({ isActive: active }) => (active ? colors.primary : colors.white)};
+  ${Text} {
+    color: ${({ isActive: active }) => (active ? colors.white : colors.grey1)};
+    font-size: 14px;
+  }
 `;
 const CategoriesContainer = styled.div`
   margin-top: 0.8rem;

--- a/client/src/components/Post/CategorySelector.tsx
+++ b/client/src/components/Post/CategorySelector.tsx
@@ -1,0 +1,43 @@
+import { Text } from '@components/common/Text';
+import colors from '@constants/colors';
+import mixin from '@style/mixin';
+import styled from 'styled-components';
+
+export default function CategorySelector() {
+  const categories = ['여성패션 잡화', '기타 물품', '가구 인테리어', '기타', 'it물품'];
+
+  return (
+    <Container>
+      <Text size="xSmall">(필수) 카테고리를 선택해주세요</Text>
+      <CategoriesContainer>
+        {categories.map((category) => (
+          <ItemWrapper>
+            <Text size="small">{category}</Text>
+          </ItemWrapper>
+        ))}
+      </CategoriesContainer>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  padding: 24px 0;
+  border-bottom: 1px solid ${colors.grey3};
+  color: ${colors.grey1};
+  width: 100%;
+  overflow-x: hidden;
+  ${Text} {
+    color: ${colors.grey1};
+  }
+`;
+const ItemWrapper = styled.div`
+  padding: 4px 16px;
+  border: 1px solid ${colors.grey3};
+  border-radius: 999px;
+  white-space: nowrap;
+`;
+const CategoriesContainer = styled.div`
+  margin-top: 0.8rem;
+  ${mixin.flexMixin({ align: 'center' })};
+  gap: 4px;
+`;

--- a/client/src/components/Post/CircleXButton.tsx
+++ b/client/src/components/Post/CircleXButton.tsx
@@ -1,0 +1,38 @@
+import XIcon from '@assets/icons/XIcon';
+import colors from '@constants/colors';
+import mixin from '@style/mixin';
+import styled from 'styled-components';
+
+export default function CircleXButton() {
+  return (
+    <CircleButtonWrapper>
+      <XIcon />
+    </CircleButtonWrapper>
+  );
+}
+
+const CircleButtonWrapper = styled.button`
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: ${colors.black};
+  border-radius: 50%;
+  ${mixin.flexMixin({ justify: 'center', align: 'center' })}
+
+  :hover {
+    background-color: ${colors.grey1};
+  }
+
+  :disabled {
+    background-color: ${colors.secondary};
+  }
+
+  :focus {
+    border: 1px solid ${colors.tertiary};
+  }
+
+  svg {
+    stroke: ${colors.white};
+    width: 1rem;
+    height: 1rem;
+  }
+`;

--- a/client/src/components/Post/DescriptionTextArea.tsx
+++ b/client/src/components/Post/DescriptionTextArea.tsx
@@ -30,8 +30,17 @@ const CustomTextArea = styled.div`
     border: 0;
     outline: 0;
   }
-  &[contentEditable='true']:empty:not(:focus)::before {
+  &[contenteditable='true'] {
+    position: relative;
+  }
+
+  &[contenteditable='true']:empty:before {
     content: attr(placeholder);
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 4px;
+    margin: auto;
     color: ${colors.grey2};
   }
 `;

--- a/client/src/components/Post/DescriptionTextArea.tsx
+++ b/client/src/components/Post/DescriptionTextArea.tsx
@@ -1,0 +1,37 @@
+import colors from '@constants/colors';
+import { fontSize } from '@constants/fonts';
+import styled from 'styled-components';
+
+export default function DescriptionTextArea() {
+  return (
+    <Container>
+      <CustomTextArea contentEditable placeholder="게시글 내용을 작성해주세요" />
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  padding: 24px 0 18px 0;
+`;
+
+const CustomTextArea = styled.div`
+  width: 100%;
+  height: 100%;
+  color: ${colors.black};
+  line-height: 22px;
+
+  background-color: ${colors.white};
+  border: 0;
+  font-size: ${fontSize.medium};
+  ::placeholder {
+    color: ${colors.grey1};
+  }
+  :focus {
+    border: 0;
+    outline: 0;
+  }
+  &[contentEditable='true']:empty:not(:focus)::before {
+    content: attr(placeholder);
+    color: ${colors.grey2};
+  }
+`;

--- a/client/src/components/Post/ImageUploader.tsx
+++ b/client/src/components/Post/ImageUploader.tsx
@@ -1,0 +1,71 @@
+import ImageIcon from '@assets/icons/ImageIcon';
+import { Text } from '@components/common/Text';
+import colors from '@constants/colors';
+import mixin from '@style/mixin';
+import styled from 'styled-components';
+import UploadedImage from './UploadedImage';
+
+export default function ImageUploader() {
+  return (
+    <>
+      <Container>
+        <ImageInput>
+          <ImageIcon />
+          <Flex>
+            <Text size="xSmall">1</Text>
+            <Text size="xSmall">/</Text>
+            <Text size="xSmall">10</Text>
+          </Flex>
+
+          <input type="file" />
+        </ImageInput>
+        <UploadedImage />
+      </Container>
+      <div />
+    </>
+  );
+}
+
+const Container = styled.div`
+  padding: 24px 0;
+  border-bottom: 1px solid ${colors.grey3};
+  ${mixin.flexMixin({})}
+  gap: 1.2rem;
+`;
+
+// const ImageInput = styled.input`
+
+// `
+const ImageInput = styled.div`
+  --size: 6rem;
+  background-color: ${colors.offWhite};
+  width: var(--size);
+  height: var(--size);
+  border-radius: 8px;
+  ${mixin.flexMixin({ align: 'center', justify: 'center', direction: 'column' })}
+  gap: 4px;
+  border: 1px solid ${colors.grey3};
+
+  input[type='file'] {
+    width: var(--size);
+    height: var(--size);
+    position: absolute;
+    top: 0;
+    left: 0;
+    opacity: 0;
+    cursor: pointer;
+  }
+  ${Text} {
+    color: ${colors.grey1};
+  }
+
+  svg {
+    stroke-width: 1px;
+    stroke: ${colors.grey1};
+  }
+`;
+
+const Flex = styled.div`
+  ${mixin.flexMixin({})};
+  gap: 2px;
+`;

--- a/client/src/components/Post/PriceInput.tsx
+++ b/client/src/components/Post/PriceInput.tsx
@@ -2,11 +2,11 @@ import colors from '@constants/colors';
 import { fontSize } from '@constants/fonts';
 import styled from 'styled-components';
 
-export default function TitleInput() {
+export default function PriceInput() {
   return (
     <>
       <Container>
-        <CustomInput placeholder="글 제목" />
+        <CustomInput placeholder="글 제목" value="₩ 169,000" />
       </Container>
       <div />
     </>
@@ -14,12 +14,14 @@ export default function TitleInput() {
 }
 
 const Container = styled.div`
-  padding: 24px 0;
+  padding: 24px 0 18px 0;
+  border-bottom: 1px solid ${colors.grey3};
 `;
 
 const CustomInput = styled.input`
   width: 100%;
   color: ${colors.black};
+
   background-color: ${colors.white};
   border: 0;
   font-size: ${fontSize.large};

--- a/client/src/components/Post/RegionFooter.tsx
+++ b/client/src/components/Post/RegionFooter.tsx
@@ -19,6 +19,7 @@ export default function RegionFooter() {
 
 const Container = styled.div`
   position: absolute;
+  color: ${colors.black};
   bottom: 0;
   left: 0;
   width: 100%;

--- a/client/src/components/Post/RegionFooter.tsx
+++ b/client/src/components/Post/RegionFooter.tsx
@@ -1,0 +1,35 @@
+import MapPinIcon from '@assets/icons/MapPinIcon';
+import { Text } from '@components/common/Text';
+import colors from '@constants/colors';
+import { padding } from '@constants/padding';
+import mixin from '@style/mixin';
+import styled from 'styled-components';
+
+export default function RegionFooter() {
+  return (
+    <>
+      <Container>
+        <MapPinIcon />
+        <Text size="small">역삼동</Text>
+      </Container>
+      <div />
+    </>
+  );
+}
+
+const Container = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: 12px ${padding.pageSide};
+  border-top: 1px solid ${colors.grey3};
+  ${mixin.flexMixin({ align: 'center' })}
+  gap: 4px;
+
+  svg {
+    stroke: ${colors.black};
+    width: 1rem;
+    height: 1rem;
+  }
+`;

--- a/client/src/components/Post/TitleInput.tsx
+++ b/client/src/components/Post/TitleInput.tsx
@@ -4,12 +4,9 @@ import styled from 'styled-components';
 
 export default function TitleInput() {
   return (
-    <>
-      <Container>
-        <CustomInput placeholder="글 제목" />
-      </Container>
-      <div />
-    </>
+    <Container>
+      <CustomInput placeholder="글 제목" />
+    </Container>
   );
 }
 

--- a/client/src/components/Post/TitleInput.tsx
+++ b/client/src/components/Post/TitleInput.tsx
@@ -1,0 +1,32 @@
+import colors from '@constants/colors';
+import { fontSize } from '@constants/fonts';
+import mixin from '@style/mixin';
+import styled from 'styled-components';
+
+export default function TitleInput() {
+  return (
+    <>
+      <Container>
+        <CustomInput placeholder="글 제목" />
+      </Container>
+      <div />
+    </>
+  );
+}
+
+const Container = styled.div`
+  padding: 24px 0;
+`;
+
+const CustomInput = styled.input`
+  width: 100%;
+  background-color: ${colors.white};
+  border: 0;
+  font-size: ${fontSize.medium};
+  ::placeholder {
+    color: ${colors.grey1};
+  }
+  :focus {
+    border: 0;
+  }
+`;

--- a/client/src/components/Post/TitleInput.tsx
+++ b/client/src/components/Post/TitleInput.tsx
@@ -15,14 +15,14 @@ export default function TitleInput() {
 }
 
 const Container = styled.div`
-  padding: 24px 0;
+  padding: 24px 0 18px 0;
 `;
 
 const CustomInput = styled.input`
   width: 100%;
   background-color: ${colors.white};
   border: 0;
-  font-size: ${fontSize.medium};
+  font-size: ${fontSize.large};
   ::placeholder {
     color: ${colors.grey1};
   }

--- a/client/src/components/Post/UploadedImage.tsx
+++ b/client/src/components/Post/UploadedImage.tsx
@@ -1,0 +1,38 @@
+import colors from '@constants/colors';
+import styled from 'styled-components';
+import CircleXButton from './CircleXButton';
+
+export default function UploadedImage() {
+  return (
+    <Container>
+      <img
+        src="https://image.msscdn.net/images/goods_img/20210907/2113853/2113853_2_500.jpg?t=20220405141136"
+        alt="신발"
+      />
+      <CircleXButton />
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  --size: 6rem;
+
+  position: relative;
+  background-color: ${colors.offWhite};
+  width: var(--size);
+  height: var(--size);
+  border-radius: 8px;
+  border: 1px solid ${colors.grey3};
+
+  img {
+    width: 100%;
+    height: 100%;
+  }
+
+  button {
+    position: absolute;
+    right: 0;
+    top: 0;
+    transform: translate(50%, -50%);
+  }
+`;

--- a/client/src/components/Post/index.tsx
+++ b/client/src/components/Post/index.tsx
@@ -1,0 +1,17 @@
+import CategorySelector from './CategorySelector';
+import DescriptionTextArea from './DescriptionTextArea';
+import ImageUploader from './ImageUploader';
+import PriceInput from './PriceInput';
+import TitleInput from './TitleInput';
+
+export default function Post() {
+  return (
+    <>
+      <ImageUploader />
+      <TitleInput />
+      <CategorySelector />
+      <PriceInput />
+      <DescriptionTextArea />
+    </>
+  );
+}

--- a/client/src/pages/PostPage.tsx
+++ b/client/src/pages/PostPage.tsx
@@ -1,0 +1,30 @@
+import CheckIcon from '@assets/icons/CheckIcon';
+import NavigationBar from '@components/common/NavigationBar';
+import PageContainer from '@components/common/PageContainer';
+import Post from '@components/Post';
+import RegionFooter from '@components/Post/RegionFooter';
+import { padding } from '@constants/padding';
+import styled from 'styled-components';
+
+export default function PostPage() {
+  return (
+    <>
+      <NavigationBar title="글쓰기" actionItem={<CheckIcon />} />
+      <PostPageWrapper>
+        <form>
+          <Post />
+        </form>
+        <RegionFooter />
+      </PostPageWrapper>
+    </>
+  );
+}
+
+const PostPageWrapper = styled(PageContainer)`
+  position: relative;
+  padding-right: ${padding.pageSide};
+  padding-left: ${padding.pageSide};
+  width: 100%;
+  height: 100%;
+  background-color: white;
+`;

--- a/client/src/pages/Routes.tsx
+++ b/client/src/pages/Routes.tsx
@@ -3,6 +3,7 @@ import ErrorPage from './ErrorPage';
 import LoginPage from './LoginPage';
 import MainPage from './MainPage';
 import OAuthRedirectPage from './OAuthRedirectPage';
+import PostPage from './PostPage';
 import SignUpPage from './SignUpPage';
 
 export default function Routes() {
@@ -14,6 +15,7 @@ export default function Routes() {
       <Route path="/oauth-redirect" element={<OAuthRedirectPage />} />
       <Route path="/signUp" element={<SignUpPage />} />
       <Route path="/error" element={<ErrorPage />} />
+      <Route path="/post" element={<PostPage />} />
       <Route path="/" element={isLogin ? <MainPage /> : <Navigate to="/login" />} />
     </RouterRoutes>
   );


### PR DESCRIPTION
## 작업내용 요약

- post 페이지는 유저가 몰품판매 설명을 작성할 수 있는 페이지의 마크업을 작성했습니다. 

## 작업의도

- 개시글 내용을 작성해주세요 부분은  textarea대신에 contentEditable 속성이 true인 div를 사용했습니다. 
- 줄이 늘어날수록 textarea는 높이가 늘어나지 않는 반면 contentEditable을 적용한 div는 줄이 늘어나면 동시에 높이도 늘어나서 좋은 UX를 가지고 있습니다. 

<img width="495" alt="image" src="https://user-images.githubusercontent.com/78121870/185800302-80b7719a-943a-4fae-a53a-012199a2e673.png">


## 관련이슈

- #31
