### PR TITLE
Feat/28 detailpage (상품 디테일 페이지 마크업 및 드롭다운 틀 구현)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import portalUtil from '@utils/portal';
 import { useRef, useEffect } from 'react';
 import mixin from '@style/mixin';
+import colors from '@constants/colors';
 
 export default function App() {
   const displayRef = useRef<HTMLDivElement | null>(null);
@@ -32,6 +33,7 @@ const Display = styled.div`
   position: relative;
   width: 26rem;
   height: 56rem;
+  background-color: ${colors.white};
   overflow-x: hidden;
   overflow-y: auto;
   border: 5px solid black;

--- a/client/src/apis/product.ts
+++ b/client/src/apis/product.ts
@@ -15,6 +15,7 @@ export async function getProductDetail(productId?: number) {
   if (!productId) throw new Error('상품이 존재하지 않습니다.');
   try {
     const { data: product } = await myAxios.get<IProduct>(`/products/${productId}`);
+    const a = product.salesStatus;
     return product;
   } catch (e) {
     throw new Error('상품 조회에 실패했습니다.');

--- a/client/src/apis/product.ts
+++ b/client/src/apis/product.ts
@@ -15,7 +15,6 @@ export async function getProductDetail(productId?: number) {
   if (!productId) throw new Error('상품이 존재하지 않습니다.');
   try {
     const { data: product } = await myAxios.get<IProduct>(`/products/${productId}`);
-    const a = product.salesStatus;
     return product;
   } catch (e) {
     throw new Error('상품 조회에 실패했습니다.');

--- a/client/src/apis/product.ts
+++ b/client/src/apis/product.ts
@@ -1,4 +1,4 @@
-import { GetRegionProductAPIDto } from '@customTypes/product';
+import { GetRegionProductAPIDto, IProduct } from '@customTypes/product';
 import myAxios from './myAxios';
 
 export async function getRegionProducts(regionId?: number) {
@@ -8,5 +8,15 @@ export async function getRegionProducts(regionId?: number) {
     return res.data;
   } catch (e) {
     throw new Error('검색에 실패했습니다.');
+  }
+}
+
+export async function getProductDetail(productId?: number) {
+  if (!productId) throw new Error('상품이 존재하지 않습니다.');
+  try {
+    const { data: product } = await myAxios.get<IProduct>(`/products/${productId}`);
+    return product;
+  } catch (e) {
+    throw new Error('상품 조회에 실패했습니다.');
   }
 }

--- a/client/src/assets/icons/ChevronDown.tsx
+++ b/client/src/assets/icons/ChevronDown.tsx
@@ -1,0 +1,7 @@
+export default function ChevronDown() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M4 8L12 16L20 8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/client/src/assets/icons/ChevronLeft.tsx
+++ b/client/src/assets/icons/ChevronLeft.tsx
@@ -1,13 +1,7 @@
 function ChevronLeft() {
   return (
     <svg width="10" height="18" viewBox="0 0 10 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M9 17L1 9L9 1"
-        stroke="#222222"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <path d="M9 17L1 9L9 1" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }

--- a/client/src/assets/icons/MoreIcon.tsx
+++ b/client/src/assets/icons/MoreIcon.tsx
@@ -1,0 +1,24 @@
+export default function MoreIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M12 13C12.5523 13 13 12.5523 13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12C11 12.5523 11.4477 13 12 13Z"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M12 6C12.5523 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5C11 5.55228 11.4477 6 12 6Z"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M12 20C12.5523 20 13 19.5523 13 19C13 18.4477 12.5523 18 12 18C11.4477 18 11 18.4477 11 19C11 19.5523 11.4477 20 12 20Z"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/client/src/components/ChatButton/index.tsx
+++ b/client/src/components/ChatButton/index.tsx
@@ -1,0 +1,6 @@
+import Button from '@components/common/Button';
+
+// Todo: 서버 쪽에서 채팅 엔티티와 기능 개발하면 수정하기
+export default function ChatButton() {
+  return <Button size="medium">채팅 목록 보기</Button>;
+}

--- a/client/src/components/DetailPageNavigationBar/index.tsx
+++ b/client/src/components/DetailPageNavigationBar/index.tsx
@@ -1,0 +1,13 @@
+import NavigationBar from '@components/common/NavigationBar';
+import MoreButton from '@components/MoreButton';
+import colors from '@constants/colors';
+
+export default function DetailPageNavigationBar() {
+  return (
+    <NavigationBar
+      color={colors.red}
+      shadowColor="transparent"
+      actionItem={<MoreButton color="red" />}
+    />
+  );
+}

--- a/client/src/components/DetailPageNavigationBar/index.tsx
+++ b/client/src/components/DetailPageNavigationBar/index.tsx
@@ -1,13 +1,18 @@
 import NavigationBar from '@components/common/NavigationBar';
+import ImageSlider from '@components/ImageSlider.tsx';
 import MoreButton from '@components/MoreButton';
 import colors from '@constants/colors';
 
 export default function DetailPageNavigationBar() {
   return (
-    <NavigationBar
-      color={colors.red}
-      shadowColor="transparent"
-      actionItem={<MoreButton color="red" />}
-    />
+    <>
+      <NavigationBar
+        color={colors.white}
+        backgroundColor="transparent"
+        shadowColor="transparent"
+        actionItem={<MoreButton color={colors.white} />}
+      />
+      <ImageSlider images={['1']} />
+    </>
   );
 }

--- a/client/src/components/DetailPageNavigationBar/index.tsx
+++ b/client/src/components/DetailPageNavigationBar/index.tsx
@@ -1,18 +1,14 @@
 import NavigationBar from '@components/common/NavigationBar';
-import ImageSlider from '@components/ImageSlider.tsx';
 import MoreButton from '@components/MoreButton';
 import colors from '@constants/colors';
 
 export default function DetailPageNavigationBar() {
   return (
-    <>
-      <NavigationBar
-        color={colors.white}
-        backgroundColor="transparent"
-        shadowColor="transparent"
-        actionItem={<MoreButton color={colors.white} />}
-      />
-      <ImageSlider images={['1']} />
-    </>
+    <NavigationBar
+      color={colors.white}
+      backgroundColor="transparent"
+      shadowColor="transparent"
+      actionItem={<MoreButton color={colors.white} />}
+    />
   );
 }

--- a/client/src/components/ImageSlider.tsx/index.tsx
+++ b/client/src/components/ImageSlider.tsx/index.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+interface ImageSliderProps {
+  images: string[];
+}
+
+export default function ImageSlider({ images }: ImageSliderProps) {
+  return <Container />;
+}
+
+const Container = styled.div`
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0.24) 0%,
+    rgba(0, 0, 0, 0) 16.52%,
+    rgba(0, 0, 0, 0) 87.36%,
+    rgba(0, 0, 0, 0.24) 100%
+  );
+  width: 26rem;
+  height: 26rem;
+`;

--- a/client/src/components/MoreButton/index.tsx
+++ b/client/src/components/MoreButton/index.tsx
@@ -1,0 +1,38 @@
+import MoreIcon from '@assets/icons/MoreIcon';
+import DropDown from '@components/common/DropDown';
+import colors from '@constants/colors';
+import { useState } from 'react';
+import styled from 'styled-components';
+
+interface MoreButtonProps {
+  color?: string;
+}
+
+export default function MoreButton({ color }: MoreButtonProps) {
+  const [isDropDownOpen, setIsDropDownOpen] = useState(false);
+  const moreUtils = [
+    {
+      name: '수정하기',
+      onClick: () => alert('수정하기'),
+    },
+    {
+      name: '삭제하기',
+      onClick: () => alert('삭제하기'),
+      color: colors.red,
+    },
+  ];
+  return (
+    <Container color={color} onClick={() => setIsDropDownOpen((prev) => !prev)}>
+      <MoreIcon />
+      {isDropDownOpen && <DropDown dropDownItems={moreUtils} top="2rem" right="0" />}
+    </Container>
+  );
+}
+
+const Container = styled.button<{ color?: string }>`
+  svg {
+    width: 1.5rem;
+    height: 1.5rem;
+    stroke: ${({ color }) => color};
+  }
+`;

--- a/client/src/components/ProductItem/index.tsx
+++ b/client/src/components/ProductItem/index.tsx
@@ -1,10 +1,11 @@
+import Caption from '@components/common/Caption';
 import CountIndicator from '@components/common/CountIndicator';
 import { Text } from '@components/common/Text';
 import Thumbnail from '@components/common/Thumbnail';
 import colors from '@constants/colors';
 import { IProductItem } from '@customTypes/product';
 import mixin from '@style/mixin';
-import { calTimePassed } from '@utils/common';
+import { getPassedTimeString } from '@utils/common';
 import { getLastAddress } from '@utils/product';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -18,11 +19,6 @@ interface ProductItemProps {
 export default function ProductItem({ productInfo, UtilButton }: ProductItemProps) {
   const navigate = useNavigate();
 
-  const getPassedTimeString = (timeString: string) => {
-    const createdTime = new Date(timeString);
-    return `${calTimePassed(createdTime)} 전`;
-  };
-
   const moveToDetailPage = () => {
     navigate(`/product/${productInfo.id}`);
   };
@@ -35,9 +31,7 @@ export default function ProductItem({ productInfo, UtilButton }: ProductItemProp
         <Text size="large" weight="bold">
           {name}
         </Text>
-        <Text color={colors.grey1}>{`${getLastAddress(region.address)} · ${getPassedTimeString(
-          createdAt,
-        )}`}</Text>
+        <Caption captions={[getLastAddress(region.address), getPassedTimeString(createdAt)]} />
         <Text weight="bold">{`${price.toLocaleString()}원`}</Text>
       </ProductInfoContainer>
       <UtilButtonWrapper>{UtilButton}</UtilButtonWrapper>

--- a/client/src/components/ProductItem/index.tsx
+++ b/client/src/components/ProductItem/index.tsx
@@ -6,7 +6,7 @@ import colors from '@constants/colors';
 import { IProductItem } from '@customTypes/product';
 import mixin from '@style/mixin';
 import { getPassedTimeString } from '@utils/common';
-import { getLastAddress } from '@utils/product';
+import { getLastAddress, getPriceString } from '@utils/product';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -32,7 +32,7 @@ export default function ProductItem({ productInfo, UtilButton }: ProductItemProp
           {name}
         </Text>
         <Caption captions={[getLastAddress(region.address), getPassedTimeString(createdAt)]} />
-        <Text weight="bold">{`${price.toLocaleString()}원`}</Text>
+        <Text weight="bold">{getPriceString(price)}</Text>
       </ProductInfoContainer>
       <UtilButtonWrapper>{UtilButton}</UtilButtonWrapper>
       <CountIndicatorWrapper>

--- a/client/src/components/ProductItem/index.tsx
+++ b/client/src/components/ProductItem/index.tsx
@@ -7,6 +7,7 @@ import mixin from '@style/mixin';
 import { calTimePassed } from '@utils/common';
 import { getLastAddress } from '@utils/product';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 interface ProductItemProps {
@@ -15,14 +16,20 @@ interface ProductItemProps {
 }
 
 export default function ProductItem({ productInfo, UtilButton }: ProductItemProps) {
+  const navigate = useNavigate();
+
   const getPassedTimeString = (timeString: string) => {
     const createdTime = new Date(timeString);
     return `${calTimePassed(createdTime)} 전`;
   };
 
+  const moveToDetailPage = () => {
+    navigate(`/product/${productInfo.id}`);
+  };
+
   const { thumbnail, name, region, createdAt, price, likedUsers } = productInfo;
   return (
-    <Container>
+    <Container onClick={moveToDetailPage}>
       <Thumbnail src={thumbnail} size="medium" />
       <ProductInfoContainer>
         <Text size="large" weight="bold">

--- a/client/src/components/SaleStateSelector/index.tsx
+++ b/client/src/components/SaleStateSelector/index.tsx
@@ -1,0 +1,45 @@
+import ChevronDown from '@assets/icons/ChevronDown';
+import DropDown from '@components/common/DropDown';
+import { Text } from '@components/common/Text';
+import colors from '@constants/colors';
+import { SalesStatusType, SalesStatusEnum } from '@customTypes/product';
+import mixin from '@style/mixin';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+interface SaleStateSelectorProps {
+  initialStatus: SalesStatusType;
+}
+
+export default function SaleStateSelector({ initialStatus }: SaleStateSelectorProps) {
+  const [isDropDownOpen, setIsDropDownOpen] = useState(false);
+  const [salesStatus, setSalesStatus] = useState<SalesStatusType>(initialStatus);
+  const dropDownItems = Object.entries(SalesStatusEnum).map(([enumKey, enumValue]) => ({
+    name: enumValue,
+    onClick: () => setSalesStatus(enumKey as SalesStatusType),
+  }));
+
+  return (
+    <Container onClick={() => setIsDropDownOpen((prev) => !prev)}>
+      <Text size="small" weight="bold">
+        {SalesStatusEnum[salesStatus]}
+      </Text>
+      <ChevronDown />
+      {isDropDownOpen && <DropDown dropDownItems={dropDownItems} top="3rem" left="0" />}
+    </Container>
+  );
+}
+
+const Container = styled.button`
+  position: relative;
+  ${mixin.flexMixin({ align: 'center', justify: 'space-between' })}
+  width: 7.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid ${colors.grey2};
+  padding: 0.625rem 1rem;
+
+  svg {
+    stroke: ${colors.grey1};
+    scale: 0.8;
+  }
+`;

--- a/client/src/components/common/Caption.tsx
+++ b/client/src/components/common/Caption.tsx
@@ -1,0 +1,16 @@
+import colors from '@constants/colors';
+import { Text, TextSizeType } from './Text';
+
+interface CaptionProps {
+  captions: (string | undefined)[];
+  size?: TextSizeType;
+}
+
+export default function Caption({ captions, size }: CaptionProps) {
+  const captionString = captions.join(' · ');
+  return (
+    <Text color={colors.grey1} size={size}>
+      {captionString}
+    </Text>
+  );
+}

--- a/client/src/components/common/DropDown.tsx
+++ b/client/src/components/common/DropDown.tsx
@@ -1,0 +1,57 @@
+import colors from '@constants/colors';
+import styled, { css } from 'styled-components';
+import { Text } from './Text';
+
+interface IDropDownItem {
+  name: string;
+  onClick?: () => void;
+  color?: string;
+}
+
+interface DropDownProps {
+  dropDownItems: IDropDownItem[];
+  top?: string;
+  bottom?: string;
+  left?: string;
+  right?: string;
+}
+
+export default function DropDown({ dropDownItems, top, bottom, left, right }: DropDownProps) {
+  return (
+    <Container top={top} bottom={bottom} left={left} right={right}>
+      {dropDownItems.map((dropDownItem) => {
+        const { name, onClick, color } = dropDownItem;
+        return (
+          <DropDownItem key={name} onClick={onClick}>
+            <Text size="small" weight="bold" color={color}>
+              {name}
+            </Text>
+          </DropDownItem>
+        );
+      })}
+    </Container>
+  );
+}
+
+const Container = styled.ul<{ top?: string; bottom?: string; left?: string; right?: string }>`
+  position: absolute;
+  ${({ top, bottom, left, right }) => css`
+    top: ${top};
+    bottom: ${bottom};
+    left: ${left};
+    right: ${right};
+  `}
+  z-index: 20;
+  overflow: hidden;
+  border-radius: 0.75rem;
+  box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5), 0px 2px 4px rgba(0, 0, 0, 0.25);
+  background-color: ${colors.grey3};
+`;
+
+const DropDownItem = styled.li`
+  width: 10rem;
+  height: 3rem;
+  padding: 1rem;
+  text-align: left;
+  background-color: ${colors.offWhite};
+`;

--- a/client/src/components/common/DropDown.tsx
+++ b/client/src/components/common/DropDown.tsx
@@ -54,4 +54,13 @@ const DropDownItem = styled.li`
   padding: 1rem;
   text-align: left;
   background-color: ${colors.offWhite};
+  border-bottom: 1px solid ${colors.grey3};
+
+  :hover {
+    background-color: ${colors.grey3};
+  }
+
+  :last-child {
+    border: none;
+  }
 `;

--- a/client/src/components/common/NavigationBar.tsx
+++ b/client/src/components/common/NavigationBar.tsx
@@ -8,15 +8,19 @@ import mixin from '@style/mixin';
 import { componentSize } from '@constants/componentSize';
 
 interface NavigationBarProps {
-  title: string;
+  title?: string;
   navigationButtonHandler?: () => void;
   actionItem?: React.ReactNode;
+  color?: string;
+  shadowColor?: string;
 }
 
 export default function NavigationBar({
   title,
   navigationButtonHandler,
   actionItem,
+  color,
+  shadowColor,
 }: NavigationBarProps) {
   const navigate = useNavigate();
 
@@ -24,17 +28,17 @@ export default function NavigationBar({
     navigate(-1);
   };
   return (
-    <Container>
-      <NavigationButton onClick={navigationButtonHandler || defaultNavigationHandler}>
+    <Container shadowColor={shadowColor}>
+      <NavigationButton onClick={navigationButtonHandler || defaultNavigationHandler} color={color}>
         <ChevronLeft />
       </NavigationButton>
-      <Text>{title}</Text>
+      <Text color={color}>{title}</Text>
       <ActionItemContainer>{actionItem}</ActionItemContainer>
     </Container>
   );
 }
 
-const Container = styled.div`
+const Container = styled.div<{ shadowColor?: string }>`
   position: absolute;
   z-index: 10;
   top: 0;
@@ -43,10 +47,10 @@ const Container = styled.div`
   height: ${componentSize.navigationHeader.height};
   padding: 1rem 1.5rem;
   background-color: ${colors.offWhite};
-  box-shadow: inset 0px -1px 0px ${colors.grey3};
+  box-shadow: inset 0px -1px 0px ${({ shadowColor }) => shadowColor || colors.grey3};
 `;
 
-const NavigationButton = styled.button`
+const NavigationButton = styled.button<{ color?: string }>`
   position: absolute;
   top: 1.25rem;
   left: 1.5rem;
@@ -54,6 +58,7 @@ const NavigationButton = styled.button`
   svg {
     width: 0.5rem;
     height: 1rem;
+    stroke: ${({ color }) => color || colors.black};
   }
 `;
 

--- a/client/src/components/common/NavigationBar.tsx
+++ b/client/src/components/common/NavigationBar.tsx
@@ -12,6 +12,7 @@ interface NavigationBarProps {
   navigationButtonHandler?: () => void;
   actionItem?: React.ReactNode;
   color?: string;
+  backgroundColor?: string;
   shadowColor?: string;
 }
 
@@ -20,6 +21,7 @@ export default function NavigationBar({
   navigationButtonHandler,
   actionItem,
   color,
+  backgroundColor,
   shadowColor,
 }: NavigationBarProps) {
   const navigate = useNavigate();
@@ -28,7 +30,7 @@ export default function NavigationBar({
     navigate(-1);
   };
   return (
-    <Container shadowColor={shadowColor}>
+    <Container backgroundColor={backgroundColor} shadowColor={shadowColor}>
       <NavigationButton onClick={navigationButtonHandler || defaultNavigationHandler} color={color}>
         <ChevronLeft />
       </NavigationButton>
@@ -38,7 +40,7 @@ export default function NavigationBar({
   );
 }
 
-const Container = styled.div<{ shadowColor?: string }>`
+const Container = styled.div<{ backgroundColor?: string; shadowColor?: string }>`
   position: absolute;
   z-index: 10;
   top: 0;
@@ -46,7 +48,7 @@ const Container = styled.div<{ shadowColor?: string }>`
   width: 100%;
   height: ${componentSize.navigationHeader.height};
   padding: 1rem 1.5rem;
-  background-color: ${colors.offWhite};
+  background-color: ${({ backgroundColor }) => backgroundColor || colors.offWhite};
   box-shadow: inset 0px -1px 0px ${({ shadowColor }) => shadowColor || colors.grey3};
 `;
 

--- a/client/src/components/common/Text.tsx
+++ b/client/src/components/common/Text.tsx
@@ -1,7 +1,7 @@
 import colors from '@constants/colors';
 import styled from 'styled-components';
 
-type TextSizeType = 'large' | 'medium' | 'small' | 'xSmall';
+export type TextSizeType = 'large' | 'medium' | 'small' | 'xSmall';
 type FontWeightType = 'bolder' | 'bold' | 'medium';
 
 const textSizeMap = {

--- a/client/src/customTypes/product.ts
+++ b/client/src/customTypes/product.ts
@@ -11,10 +11,11 @@ export interface IProduct {
   salesStatus: SalesStatusType;
   createdAt: string;
   updatedAt: string;
-  thumbnail: JSON;
+  thumbnails: JSON;
   description: string;
   views: number;
-  writer: IUser;
+  seller: IUser;
+  likedUsers: ILikedUser[];
 }
 
 export interface ILikedUser {
@@ -23,9 +24,11 @@ export interface ILikedUser {
 }
 
 export interface IProductItem
-  extends Pick<IProduct, 'id' | 'name' | 'price' | 'region' | 'salesStatus' | 'createdAt'> {
+  extends Pick<
+    IProduct,
+    'id' | 'name' | 'price' | 'region' | 'salesStatus' | 'createdAt' | 'likedUsers'
+  > {
   thumbnail: string;
-  likedUsers: ILikedUser[];
 }
 
 export interface GetRegionProductAPIDto {

--- a/client/src/customTypes/product.ts
+++ b/client/src/customTypes/product.ts
@@ -1,7 +1,13 @@
 import { IRegion } from './region';
 import { IUser } from './user';
 
-type SalesStatusType = 'sale' | 'reserved' | 'sold';
+export type SalesStatusType = keyof typeof SalesStatusEnum;
+
+export enum SalesStatusEnum {
+  sale = '판매중',
+  reserved = '예약중',
+  sold = '판매완료',
+}
 
 export interface IProduct {
   id: number;

--- a/client/src/customTypes/user.ts
+++ b/client/src/customTypes/user.ts
@@ -4,7 +4,7 @@ import { IRegion } from './region';
 export interface IUser {
   id: number;
   name: string;
-  regions?: IRegion[];
+  regions: IRegion[];
 }
 
 export interface LoginAPIResponseDto {

--- a/client/src/customTypes/user.ts
+++ b/client/src/customTypes/user.ts
@@ -2,8 +2,9 @@ import { IOAuthUserInfo } from './auth';
 import { IRegion } from './region';
 
 export interface IUser {
+  id: number;
   name: string;
-  regions: IRegion[];
+  regions?: IRegion[];
 }
 
 export interface LoginAPIResponseDto {

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -9,6 +9,13 @@ import ImageSlider from '@components/ImageSlider.tsx';
 import styled from 'styled-components';
 import mixin from '@style/mixin';
 import { padding } from '@constants/padding';
+import { Text } from '@components/common/Text';
+import Caption from '@components/common/Caption';
+import { getLastAddress, getPriceString } from '@utils/product';
+import { getPassedTimeString } from '@utils/common';
+import colors from '@constants/colors';
+import LikeButton from '@components/common/LikeButton';
+import ChatButton from '@components/ChatButton';
 
 export default function DetailPage() {
   const { productId } = useParams();
@@ -20,7 +27,7 @@ export default function DetailPage() {
   if (!product) {
     return <LoadingIndicator />;
   }
-
+  const { name, createdAt, region, description, views, likedUsers, seller, id, price } = product;
   return (
     <Container>
       <DetailPageNavigationBar />
@@ -29,7 +36,36 @@ export default function DetailPage() {
         {user?.id === product.seller.id && (
           <SaleStateSelector initialStatus={product.salesStatus} />
         )}
+        <DetailContent>
+          <Text size="large" weight="bold">
+            {name}
+          </Text>
+          <Caption
+            size="small"
+            captions={[getLastAddress(region.address), getPassedTimeString(createdAt)]}
+          />
+          <Description as="p" size="small">
+            {description}
+          </Description>
+        </DetailContent>
+        <Caption size="small" captions={[`관심 ${likedUsers.length}`, `조회 ${views}`]} />
+        <SellerInfo>
+          <Text size="small" weight="bolder">
+            판매자 정보
+          </Text>
+          <Text size="small" weight="bolder">
+            {seller.name}
+          </Text>
+          <Text size="small" weight="medium">
+            {getLastAddress(seller.regions[0].address)}
+          </Text>
+        </SellerInfo>
       </DetailPageBody>
+      <DetailPageFooter>
+        <LikeButton productId={id} likedUsers={likedUsers} />
+        <Text weight="bolder">{getPriceString(price)}</Text>
+        <ChatButton />
+      </DetailPageFooter>
     </Container>
   );
 }
@@ -40,5 +76,45 @@ const Container = styled.div`
 `;
 
 const DetailPageBody = styled.div`
+  width: 100%;
   padding: 0 ${padding.pageSide};
+  ${mixin.flexMixin({ direction: 'column' })}
+  gap: 1.5rem;
+`;
+
+const DetailContent = styled.section`
+  ${mixin.flexMixin({ direction: 'column' })}
+  gap: 0.75rem;
+`;
+
+const Description = styled(Text)`
+  margin: 0.5rem 0;
+`;
+
+const SellerInfo = styled.div`
+  width: 100%;
+  background-color: ${colors.offWhite};
+  padding: 1rem;
+  ${mixin.flexMixin({ align: 'center' })}
+
+  :first-child {
+    flex-grow: 1;
+  }
+`;
+
+const DetailPageFooter = styled.div`
+  position: absolute;
+  bottom: 0;
+  ${mixin.flexMixin({ align: 'center' })}
+  gap: 1rem;
+  padding: 1rem;
+  width: 100%;
+  border-top: 1px solid ${colors.grey3};
+
+  & span {
+    line-height: 2rem;
+    padding-left: 1rem;
+    flex-grow: 1;
+    border-left: 1px solid ${colors.grey3};
+  }
 `;

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -50,13 +50,13 @@ export default function DetailPage() {
         </DetailContent>
         <Caption size="small" captions={[`관심 ${likedUsers.length}`, `조회 ${views}`]} />
         <SellerInfo>
-          <Text size="small" weight="bolder">
+          <Text size="small" weight="bold">
             판매자 정보
           </Text>
           <Text size="small" weight="bolder">
             {seller.name}
           </Text>
-          <Text size="small" weight="medium">
+          <Text size="small" weight="medium" color={colors.grey1}>
             {getLastAddress(seller.regions[0].address)}
           </Text>
         </SellerInfo>
@@ -94,7 +94,13 @@ const Description = styled(Text)`
 const SellerInfo = styled.div`
   width: 100%;
   background-color: ${colors.offWhite};
-  padding: 1rem;
+  padding: 1rem 1.5rem;
+  ${mixin.flexMixin({ justify: 'space-between' })}
+  gap: 1rem;
+
+  & :first-child {
+    flex-grow: 1;
+  }
 `;
 
 const DetailPageFooter = styled.div`

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -2,12 +2,25 @@ import { useParams } from 'react-router-dom';
 import DetailPageNavigationBar from '@components/DetailPageNavigationBar';
 import { useQuery } from '@tanstack/react-query';
 import { getProductDetail } from '@apis/product';
+import { getUser } from '@apis/user';
+import SaleStateSelector from '@components/SaleStateSelector';
+import LoadingIndicator from '@components/common/LoadingIndicator';
 
-export default function ErrorPDetailPageage() {
+export default function DetailPage() {
   const { productId } = useParams();
   const { data: product } = useQuery(['product', productId], () =>
     getProductDetail(Number(productId)),
   );
+  const { data: user } = useQuery(['user'], getUser);
 
-  return <DetailPageNavigationBar />;
+  if (!product) {
+    return <LoadingIndicator />;
+  }
+
+  return (
+    <>
+      <DetailPageNavigationBar />
+      <SaleStateSelector initialStatus={product.salesStatus} />
+    </>
+  );
 }

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -1,8 +1,13 @@
 import { useParams } from 'react-router-dom';
 import DetailPageNavigationBar from '@components/DetailPageNavigationBar';
+import { useQuery } from '@tanstack/react-query';
+import { getProductDetail } from '@apis/product';
 
 export default function ErrorPDetailPageage() {
   const { productId } = useParams();
+  const { data: product } = useQuery(['product', productId], () =>
+    getProductDetail(Number(productId)),
+  );
 
   return <DetailPageNavigationBar />;
 }

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom';
+
+export default function ErrorPDetailPageage() {
+  const { productId } = useParams();
+
+  return <div>{productId}</div>;
+}

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -1,7 +1,8 @@
 import { useParams } from 'react-router-dom';
+import DetailPageNavigationBar from '@components/DetailPageNavigationBar';
 
 export default function ErrorPDetailPageage() {
   const { productId } = useParams();
 
-  return <div>{productId}</div>;
+  return <DetailPageNavigationBar />;
 }

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -95,11 +95,6 @@ const SellerInfo = styled.div`
   width: 100%;
   background-color: ${colors.offWhite};
   padding: 1rem;
-  ${mixin.flexMixin({ align: 'center' })}
-
-  :first-child {
-    flex-grow: 1;
-  }
 `;
 
 const DetailPageFooter = styled.div`

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -5,6 +5,10 @@ import { getProductDetail } from '@apis/product';
 import { getUser } from '@apis/user';
 import SaleStateSelector from '@components/SaleStateSelector';
 import LoadingIndicator from '@components/common/LoadingIndicator';
+import ImageSlider from '@components/ImageSlider.tsx';
+import styled from 'styled-components';
+import mixin from '@style/mixin';
+import { padding } from '@constants/padding';
 
 export default function DetailPage() {
   const { productId } = useParams();
@@ -18,9 +22,23 @@ export default function DetailPage() {
   }
 
   return (
-    <>
+    <Container>
       <DetailPageNavigationBar />
-      <SaleStateSelector initialStatus={product.salesStatus} />
-    </>
+      <ImageSlider images={['1']} />
+      <DetailPageBody>
+        {user?.id === product.seller.id && (
+          <SaleStateSelector initialStatus={product.salesStatus} />
+        )}
+      </DetailPageBody>
+    </Container>
   );
 }
+
+const Container = styled.div`
+  ${mixin.flexMixin({ direction: 'column' })}
+  gap: 1.5rem;
+`;
+
+const DetailPageBody = styled.div`
+  padding: 0 ${padding.pageSide};
+`;

--- a/client/src/pages/Routes.tsx
+++ b/client/src/pages/Routes.tsx
@@ -1,4 +1,5 @@
 import { Route, Routes as RouterRoutes } from 'react-router-dom';
+import DetailPage from './DetailPage';
 import ErrorPage from './ErrorPage';
 import LoginPage from './LoginPage';
 import MainPage from './MainPage';
@@ -14,6 +15,7 @@ export default function Routes() {
       <Route path="/signUp" element={<SignUpPage />} />
       <Route path="/error" element={<ErrorPage />} />
       <Route path="/" element={<MainPage />} />
+      <Route path="/product/:productId" element={<DetailPage />} />
       <Route path="/post" element={<PostPage />} />
     </RouterRoutes>
   );

--- a/client/src/utils/common.ts
+++ b/client/src/utils/common.ts
@@ -20,3 +20,8 @@ export function calTimePassed(targetDate: Date) {
   const date = Math.ceil(hours / 24);
   return `${date}일`;
 }
+
+export const getPassedTimeString = (timeString: string) => {
+  const createdTime = new Date(timeString);
+  return `${calTimePassed(createdTime)} 전`;
+};

--- a/client/src/utils/common.ts
+++ b/client/src/utils/common.ts
@@ -8,7 +8,7 @@ export function debounce<T>(callback: (...args: T[]) => void, time: number) {
   };
 }
 
-export function calTimePassed(targetDate: Date) {
+export function calculatePassedTime(targetDate: Date) {
   const millisecond = new Date().getTime() - targetDate.getTime();
   if (millisecond < 1000) return '방금';
   const seconds = Math.ceil(millisecond / 1000);
@@ -23,5 +23,5 @@ export function calTimePassed(targetDate: Date) {
 
 export const getPassedTimeString = (timeString: string) => {
   const createdTime = new Date(timeString);
-  return `${calTimePassed(createdTime)} 전`;
+  return `${calculatePassedTime(createdTime)} 전`;
 };

--- a/client/src/utils/product.ts
+++ b/client/src/utils/product.ts
@@ -1,3 +1,7 @@
 export function getLastAddress(address: string) {
   return address.split(' ').pop();
 }
+
+export function getPriceString(price: number) {
+  return `${price.toLocaleString()}원`;
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -31,6 +31,9 @@ import { UploadImageModule } from './upload-image/upload-image.module';
         entities: [__dirname + '/**/entities/*.entity.{js,ts}'],
         synchronize: true,
         namingStrategy: new SnakeNamingStrategy(),
+        extra: {
+          decimalNumbers: true,
+        },
       }),
     }),
     UserModule,

--- a/server/src/product/dto/getProductDetail.dto.ts
+++ b/server/src/product/dto/getProductDetail.dto.ts
@@ -1,0 +1,14 @@
+import { User } from 'src/user/entities/user.entity';
+import { Product } from 'src/product/entities/product.entity';
+import { OmitType, PickType } from '@nestjs/mapped-types';
+
+class ProductDetailSellerDto extends OmitType(User, ['regions']) {
+  regions: {
+    id: number;
+    address: string;
+  }[];
+}
+
+export class GetProductDetailDto extends OmitType(Product, ['seller']) {
+  seller: ProductDetailSellerDto;
+}

--- a/server/src/product/entities/product.entity.ts
+++ b/server/src/product/entities/product.entity.ts
@@ -38,7 +38,7 @@ export class Product {
   updatedAt: Date;
 
   @Column({ type: 'int' })
-  view: number;
+  views: number;
 
   @Column({ type: 'enum', enum: SalesStatusEnum })
   salesStatus: string;

--- a/server/src/product/product.controller.ts
+++ b/server/src/product/product.controller.ts
@@ -23,8 +23,9 @@ export class ProductController {
     @Res() res: Response,
     @Param('productId') productId: number,
   ) {
-    const product = await this.productService.getProduct(productId);
-    return res.status(HttpStatus.OK).json(product);
+    const parsedProductDetail =
+      await this.productService.getAndParseProductDetail(productId);
+    return res.status(HttpStatus.OK).json(parsedProductDetail);
   }
 
   @Get()

--- a/server/src/product/product.service.ts
+++ b/server/src/product/product.service.ts
@@ -3,6 +3,7 @@ import { ProductRepository } from './repository/product.repository';
 import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import { Product } from './entities/product.entity';
 import { LikeDto } from './dto/like.dto';
+import { GetProductDetailDto } from './dto/getProductDetail.dto';
 
 @Injectable()
 export class ProductService {
@@ -17,6 +18,22 @@ export class ProductService {
 
   getProduct(productId: number): Promise<Product> {
     return this.productRepository.findOneByProductId(productId);
+  }
+
+  async getAndParseProductDetail(productId: number) {
+    const {
+      seller: { regions: rawSellerRegion, ...sellerData },
+      ...restData
+    } = await this.getProduct(productId);
+    const parsedSellerRegion = rawSellerRegion.map((rawSellerRegion) => ({
+      id: rawSellerRegion.region.id,
+      address: rawSellerRegion.region.address,
+    }));
+    const parsedProduct: GetProductDetailDto = {
+      ...restData,
+      seller: { regions: parsedSellerRegion, ...sellerData },
+    };
+    return parsedProduct;
   }
 
   async deleteProduct(productId: number, userId: number) {

--- a/server/src/product/repository/product.repository.ts
+++ b/server/src/product/repository/product.repository.ts
@@ -21,7 +21,7 @@ export class ProductRepository {
     try {
       return this.repository.findOne({
         where: { id },
-        relations: ['region', 'seller', 'likedUsers'],
+        relations: ['region', 'seller.regions.region', 'likedUsers'],
       });
     } catch (e) {
       throw new HttpException(


### PR DESCRIPTION
## 작업내용 요약

<img width="444" alt="스크린샷 2022-08-23 오후 4 14 57" src="https://user-images.githubusercontent.com/95538993/186095064-fe883c88-1ba8-474c-9043-bdeeec8f1262.png">

- 상품 디테일페이지와 드롭다운 틀을 구현했습니다.

## 작업의도

- 디테일 페이지에서 각 영역별로 컴포넌트를 분리할 수 있지만 우선은 하지 않았습니다.
- 단순히 보여주기만 하는 컴포넌트의 경우 디테일페이지에서만 사용되므로 굳이 분리하지 않고 이후에 기능이 추가되거나 재사용가능한 부분이 있으면 분리하겠습니다.
- 드롭다운의 경우 기본적으로 배열로 props를 받아 구체화합니다.
- 드롭다운 바깥을 누르면 꺼지는 것은 모달과 동작방식이 비슷할 것 같아서 모달을 구현할 떄 추가하려고합니다. 

## 관련이슈

- #28 
