### PR TITLE
feat:product api에 pagination 적용

### DIFF
--- a/server/src/product/product.controller.ts
+++ b/server/src/product/product.controller.ts
@@ -37,13 +37,23 @@ export class ProductController {
     return res.status(HttpStatus.OK).json(parsedProductDetail);
   }
 
-  @Get()
   @UseAuthGuard()
+  @Get()
   async getRegionProducts(
     @Res() res: Response,
     @Query('region-id') regionId: number,
+    @Query('start') startProductId: number,
+    @Query('category-id') categoryId: number,
   ) {
-    const products = await this.productService.getRegionProducts(regionId);
+    const LIMIT = 2;
+    const { products, nextStartParam } =
+      await this.productService.getPaginationOfProductsByRegion(
+        startProductId,
+        regionId,
+        categoryId,
+        LIMIT,
+      );
+
     const parsedProducts: GetRegionProductAPIDto[] = products.map((product) => {
       const {
         id,
@@ -66,7 +76,10 @@ export class ProductController {
         thumbnail: thumbnails[0],
       };
     });
-    return res.status(HttpStatus.OK).json(parsedProducts);
+    return res.status(HttpStatus.OK).json({
+      products: parsedProducts,
+      nextStartParam: nextStartParam ? nextStartParam : -1,
+    });
   }
 
   @Delete(':productId')

--- a/server/src/product/product.service.ts
+++ b/server/src/product/product.service.ts
@@ -21,6 +21,32 @@ export class ProductService {
     return this.productRepository.findProductsByRegion(regionId);
   }
 
+  async getPaginationOfProductsByRegion(
+    startProductId: number,
+    regionId: number,
+    categoryId: number,
+    limit: number,
+  ): Promise<{
+    products: Product[];
+    nextStartParam: number | undefined;
+  }> {
+    const products = await this.productRepository.findProductsByRegionWithLimit(
+      startProductId,
+      limit,
+      regionId,
+      categoryId,
+    );
+
+    const isEnd = products[limit];
+
+    const nextStartParam = isEnd ? products[limit].id : undefined;
+    if (isEnd) {
+      products.pop();
+    }
+
+    return { products, nextStartParam };
+  }
+
   createNewProduct(createProductDto: CreateProductDto) {
     return this.productRepository.createProduct(createProductDto);
   }

--- a/server/src/product/repository/product.repository.ts
+++ b/server/src/product/repository/product.repository.ts
@@ -1,5 +1,5 @@
 import { CreateProductDto } from '../dto/createProduct.dto';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, LessThan, MoreThan, Repository } from 'typeorm';
 import { HttpException, Injectable, HttpStatus } from '@nestjs/common';
 import { Product } from '../entities/product.entity';
 import { SalesStatusEnum } from 'src/common/enums';
@@ -32,6 +32,24 @@ export class ProductRepository {
         HttpStatus.BAD_REQUEST,
       );
     }
+  }
+
+  public async findProductsByRegionWithLimit(
+    startProductId: number,
+    limit: number,
+    regionId: number,
+    categoryId: number,
+  ) {
+    return this.repository.find({
+      where: {
+        id: startProductId ? LessThan(startProductId) : undefined,
+        regionId: regionId,
+        categoryId: categoryId,
+      },
+      order: { id: 'DESC' },
+      relations: ['region', 'likedUsers'],
+      take: limit + 1,
+    });
   }
 
   public async patchProductById(


### PR DESCRIPTION
## 작업내용 요약

- product API에 pagination적용 

## 작업의도

- start를 기준으로 그것보다 id가 작은 것들을 limit를 이용해서 가져온다.
- categoryid, regionid 모두 같은 API로 처리
- 다음 params를 nextStartParam으로 전달
- 마지막이라면 nextStartParam에 -1적용

## 관련이슈

- #46 
