### PR TITLE
Feat/45 product edit 구현 

### DIFF
--- a/client/src/apis/product.ts
+++ b/client/src/apis/product.ts
@@ -1,3 +1,4 @@
+import { Category } from '@customTypes/category';
 import {
   CreateProductAPIDto,
   GetRegionProductAPIDto,
@@ -38,6 +39,15 @@ export async function createProduct(product: CreateProductAPIDto) {
 export async function updateProduct(product: PatchProductDto, productId: number) {
   try {
     const { data } = await myAxios.patch(`/products/${productId}`, product);
+    return data;
+  } catch (e) {
+    throw new Error('상품 수정에 실패했습니다.');
+  }
+}
+
+export async function getCategories() {
+  try {
+    const { data } = await myAxios.get<Category[]>(`/products/categories`);
     return data;
   } catch (e) {
     throw new Error('상품 수정에 실패했습니다.');

--- a/client/src/apis/product.ts
+++ b/client/src/apis/product.ts
@@ -1,4 +1,9 @@
-import { CreateProductAPIDto, GetRegionProductAPIDto, IProduct } from '@customTypes/product';
+import {
+  CreateProductAPIDto,
+  GetRegionProductAPIDto,
+  IProduct,
+  PatchProductDto,
+} from '@customTypes/product';
 import myAxios from './myAxios';
 
 export async function getRegionProducts(regionId?: number) {
@@ -27,5 +32,14 @@ export async function createProduct(product: CreateProductAPIDto) {
     return data;
   } catch (e) {
     throw new Error('상품 등록에 실패했습니다.');
+  }
+}
+
+export async function updateProduct(product: PatchProductDto, productId: number) {
+  try {
+    const { data } = await myAxios.patch(`/products/${productId}`, product);
+    return data;
+  } catch (e) {
+    throw new Error('상품 수정에 실패했습니다.');
   }
 }

--- a/client/src/components/MoreButton/index.tsx
+++ b/client/src/components/MoreButton/index.tsx
@@ -2,6 +2,7 @@ import MoreIcon from '@assets/icons/MoreIcon';
 import DropDown from '@components/common/DropDown';
 import colors from '@constants/colors';
 import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 interface MoreButtonProps {
@@ -10,10 +11,12 @@ interface MoreButtonProps {
 
 export default function MoreButton({ color }: MoreButtonProps) {
   const [isDropDownOpen, setIsDropDownOpen] = useState(false);
+  const { productId } = useParams();
+  const navigate = useNavigate();
   const moreUtils = [
     {
       name: '수정하기',
-      onClick: () => alert('수정하기'),
+      onClick: () => navigate(`/product/edit/${productId}`),
     },
     {
       name: '삭제하기',

--- a/client/src/components/Post/CategorySelector.tsx
+++ b/client/src/components/Post/CategorySelector.tsx
@@ -4,9 +4,15 @@ import { useForm } from '@components/CustomForm/useForm';
 import colors from '@constants/colors';
 import mixin from '@style/mixin';
 import styled from 'styled-components';
+import { useCategory } from '../../queries/useCategory';
 
-export default function CategorySelector() {
-  const categories = ['여성패션 잡화', '기타 물품', '가구 인테리어', '기타', 'it물품'];
+interface CategorySelectorProps {
+  categoryId?: number;
+}
+
+export default function CategorySelector({ categoryId: initialCategoryId }: CategorySelectorProps) {
+  // const categories = ['여성패션 잡화', '기타 물품', '가구 인테리어', '기타', 'it물품'];
+  const { data: categories } = useCategory();
 
   const validator = {
     exist: {
@@ -15,12 +21,14 @@ export default function CategorySelector() {
     },
   };
 
+  const initialValue = initialCategoryId || 1;
+
   const {
     inputValue: selectedCategoryId,
     setInputValue: setSelectedCategoryId,
     errorMessage,
     validate,
-  } = useForm('categoryId', 0, validator, { isInitialValid: true });
+  } = useForm('categoryId', initialValue, validator, { isInitialValid: true });
 
   const selectCategory = (categoryId: number) => () => {
     validate({ value: categoryId, validateProperties: ['exist'] });
@@ -34,15 +42,12 @@ export default function CategorySelector() {
         {errorMessage}
       </ValidationMessage>
       <CategoriesContainer>
-        {categories.map((category, index) => (
-          <ItemWrapper
-            key={category}
-            isActive={index === selectedCategoryId}
-            onClick={selectCategory(index)}
-          >
-            <Text>{category}</Text>
-          </ItemWrapper>
-        ))}
+        {categories &&
+          categories.map(({ name, id }) => (
+            <ItemWrapper key={id} isActive={id === selectedCategoryId} onClick={selectCategory(id)}>
+              <Text>{name}</Text>
+            </ItemWrapper>
+          ))}
       </CategoriesContainer>
     </Container>
   );

--- a/client/src/components/Post/DescriptionTextArea.tsx
+++ b/client/src/components/Post/DescriptionTextArea.tsx
@@ -4,23 +4,35 @@ import { fontSize } from '@constants/fonts';
 import { ChangeEvent } from 'react';
 import styled from 'styled-components';
 
-export default function DescriptionTextArea() {
+interface DescriptionTextAreaProps {
+  description?: string;
+}
+
+export default function DescriptionTextArea({ description }: DescriptionTextAreaProps) {
   const validator = {
     min: {
       validate: (value: string) => value.length > 0,
       errorMessage: '게시글 내용을 작성해야합니다.',
     },
   };
+  const initialValue = description || '';
 
-  const { validate, inputValue, setInputValue } = useForm('description', '', validator);
+  const { validate, setInputValue, inputValue } = useForm('description', initialValue, validator, {
+    isInitialValid: !!description,
+  });
   const onChange = ({ currentTarget }: ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = currentTarget;
     validate({ value });
     setInputValue(value);
   };
+
   return (
     <Container>
-      <CustomTextArea onChange={onChange} placeholder="게시글 내용을 작성해주세요" />
+      <CustomTextArea
+        value={inputValue}
+        onChange={onChange}
+        placeholder="게시글 내용을 작성해주세요"
+      />
     </Container>
   );
 }

--- a/client/src/components/Post/ImageUploader/index.tsx
+++ b/client/src/components/Post/ImageUploader/index.tsx
@@ -8,8 +8,8 @@ import styled from 'styled-components';
 import UploadedImage from '../UploadedImage';
 import { MAX_QUANTITY_IMG_URLS, useUploadImage } from './useUploadImage';
 
-export default function ImageUploader() {
-  const { uploadedImgUrls, actions, errorMessage } = useUploadImage();
+export default function ImageUploader({ thumbnails }: { thumbnails?: string[] }) {
+  const { uploadedImgUrls, actions, errorMessage } = useUploadImage(thumbnails);
 
   const initializeFile = (e: React.MouseEvent<HTMLInputElement>) => {
     e.currentTarget.value = '';
@@ -25,7 +25,6 @@ export default function ImageUploader() {
             <Text size="xSmall">/</Text>
             <Text size="xSmall">{MAX_QUANTITY_IMG_URLS}</Text>
           </Flex>
-
           <input
             onClick={initializeFile}
             onInput={actions.imageUpload}

--- a/client/src/components/Post/ImageUploader/useUploadImage.tsx
+++ b/client/src/components/Post/ImageUploader/useUploadImage.tsx
@@ -4,7 +4,8 @@ import { FormEvent } from 'react';
 
 export const MAX_QUANTITY_IMG_URLS = 2;
 
-export const useUploadImage = () => {
+export const useUploadImage = (thumbnails?: string[]) => {
+  const initialValue = thumbnails || [];
   const validator = {
     min: {
       validate: (value: string[]) => value.length > 0,
@@ -21,7 +22,12 @@ export const useUploadImage = () => {
     inputValue: uploadedImgUrls,
     errorMessage,
     validate,
-  } = useForm<string[], { min: () => boolean; max: () => boolean }>('thumbnails', [], validator);
+  } = useForm<string[], { min: () => boolean; max: () => boolean }>(
+    'thumbnails',
+    initialValue,
+    validator,
+    { isInitialValid: !!thumbnails },
+  );
   // const [uploadedImgUrls, setUploadedImgUrls] = useState<string[]>([]);
 
   const deleteImageFile = (imgUrl: string) => {

--- a/client/src/components/Post/PriceInput.tsx
+++ b/client/src/components/Post/PriceInput.tsx
@@ -8,7 +8,11 @@ import styled from 'styled-components';
 
 const MAX_PRICE_LENGTH = 8;
 
-export default function PriceInput() {
+interface PriceInputProps {
+  price?: number;
+}
+
+export default function PriceInput({ price: initialPrice }: PriceInputProps) {
   const validator = {
     max: {
       validate: (value: string) => value.length < MAX_PRICE_LENGTH,
@@ -16,9 +20,15 @@ export default function PriceInput() {
     },
   };
 
-  const { validate, inputValue, setInputValue, errorMessage } = useForm('price', '', validator, {
-    isInitialValid: true,
-  });
+  const initialValue = initialPrice ? formatPrice(String(initialPrice)) : '';
+  const { validate, inputValue, setInputValue, errorMessage } = useForm(
+    'price',
+    initialValue,
+    validator,
+    {
+      isInitialValid: true,
+    },
+  );
 
   const changeInputValue = ({ currentTarget }: React.FormEvent<HTMLInputElement>) => {
     const { value } = currentTarget;

--- a/client/src/components/Post/TitleInput.tsx
+++ b/client/src/components/Post/TitleInput.tsx
@@ -5,7 +5,11 @@ import React from 'react';
 import { ValidationMessage } from '@components/common/ValidationMessage';
 import { useForm } from '@components/CustomForm/useForm';
 
-export default function TitleInput() {
+interface TitleInputProps {
+  name?: string;
+}
+
+export default function TitleInput({ name }: TitleInputProps) {
   const validator = {
     min: {
       validate: (value: string) => value.length > 0,
@@ -13,7 +17,13 @@ export default function TitleInput() {
     },
   };
 
-  const { setInputValue, inputValue, validate, errorMessage } = useForm('name', '', validator);
+  const initialValue = name || '';
+  const { setInputValue, inputValue, validate, errorMessage } = useForm(
+    'name',
+    initialValue,
+    validator,
+    { isInitialValid: !!name },
+  );
 
   const inputHandler = ({ currentTarget }: React.FormEvent<HTMLInputElement>) => {
     const { value } = currentTarget;

--- a/client/src/components/Post/index.tsx
+++ b/client/src/components/Post/index.tsx
@@ -10,7 +10,7 @@ export default function Post({ product }: { product?: IProduct }) {
     <>
       <ImageUploader thumbnails={product?.thumbnails} />
       <TitleInput name={product?.name} />
-      <CategorySelector />
+      <CategorySelector categoryId={product?.category.id} />
       <PriceInput price={product?.price} />
       <DescriptionTextArea description={product?.description} />
     </>

--- a/client/src/components/Post/index.tsx
+++ b/client/src/components/Post/index.tsx
@@ -1,17 +1,18 @@
+import { IProduct } from '@customTypes/product';
 import CategorySelector from './CategorySelector';
 import DescriptionTextArea from './DescriptionTextArea';
 import ImageUploader from './ImageUploader';
 import PriceInput from './PriceInput';
 import TitleInput from './TitleInput';
 
-export default function Post() {
+export default function Post({ product }: { product?: IProduct }) {
   return (
     <>
-      <ImageUploader />
-      <TitleInput />
+      <ImageUploader thumbnails={product?.thumbnails} />
+      <TitleInput name={product?.name} />
       <CategorySelector />
-      <PriceInput />
-      <DescriptionTextArea />
+      <PriceInput price={product?.price} />
+      <DescriptionTextArea description={product?.description} />
     </>
   );
 }

--- a/client/src/customTypes/category.ts
+++ b/client/src/customTypes/category.ts
@@ -1,0 +1,4 @@
+export interface Category {
+  id: number;
+  name: string;
+}

--- a/client/src/customTypes/product.ts
+++ b/client/src/customTypes/product.ts
@@ -1,3 +1,4 @@
+import { Category } from './category';
 import { IRegion } from './region';
 import { IUser } from './user';
 
@@ -15,9 +16,11 @@ export interface IProduct {
   price: number;
   region: IRegion;
   salesStatus: SalesStatusType;
+  // categoryId: number;
   createdAt: string;
   updatedAt: string;
   thumbnails: string[];
+  category: Category;
   description: string;
   views: number;
   seller: IUser;

--- a/client/src/customTypes/product.ts
+++ b/client/src/customTypes/product.ts
@@ -17,7 +17,7 @@ export interface IProduct {
   salesStatus: SalesStatusType;
   createdAt: string;
   updatedAt: string;
-  thumbnails: JSON;
+  thumbnails: string[];
   description: string;
   views: number;
   seller: IUser;
@@ -47,6 +47,7 @@ export interface CreateProductAPIDto {
   regionId: IRegion['id'];
   thumbnails: JSON;
   description: string;
-  sellerId: number;
   categoryId: number;
 }
+
+export type PatchProductDto = Partial<CreateProductAPIDto>;

--- a/client/src/pages/PostPage.tsx
+++ b/client/src/pages/PostPage.tsx
@@ -33,7 +33,6 @@ function PostForm() {
   const { isAllValidated } = useFormValidationState();
 
   const navigate = useNavigate();
-
   const registerProduct = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isAllValidated) {

--- a/client/src/pages/ProductEditPage.tsx
+++ b/client/src/pages/ProductEditPage.tsx
@@ -1,4 +1,4 @@
-import { createProduct } from '@apis/product';
+import { getProductDetail, updateProduct } from '@apis/product';
 import { getUser } from '@apis/user';
 import NavigationBar from '@components/common/NavigationBar';
 import PageContainer from '@components/common/PageContainer';
@@ -15,20 +15,23 @@ import { CreateProductAPIDto } from '@customTypes/product';
 import { useQuery } from '@tanstack/react-query';
 import { getNumber } from '@utils/format';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
-export default function PostPage() {
+export default function ProductEditPage() {
   return (
     <FormProvider>
-      <PostForm />
+      <PostEditForm />
     </FormProvider>
   );
 }
 
-function PostForm() {
+function PostEditForm() {
   const { data: user } = useQuery(['user'], getUser);
-
+  const { productId } = useParams();
+  const { data: product } = useQuery(['product', productId], () =>
+    getProductDetail(Number(productId)),
+  );
   const { formInputMap } = useFormInputMap();
   const { isAllValidated } = useFormValidationState();
 
@@ -41,25 +44,30 @@ function PostForm() {
       return;
     }
 
-    const product = {
+    const editedProduct = {
       ...formInputMap,
       price: Number(getNumber(formInputMap.price)),
+      // region primary구현해야함
       regionId: user?.regions[0].regionId,
     } as CreateProductAPIDto;
 
     try {
-      await createProduct(product);
+      await updateProduct(editedProduct, Number(productId));
       navigate('/');
     } catch (error) {
       navigate('error');
     }
   };
 
+  if (!product) {
+    return <div />;
+  }
+
   return (
     <Form onSubmit={registerProduct}>
       <NavigationBar title="글쓰기" actionItem={<SubmitButton />} />
       <PostPageWrapper>
-        <Post />
+        <Post product={product} />
         <RegionFooter />
       </PostPageWrapper>
     </Form>

--- a/client/src/pages/Routes.tsx
+++ b/client/src/pages/Routes.tsx
@@ -5,6 +5,7 @@ import LoginPage from './LoginPage';
 import MainPage from './MainPage';
 import OAuthRedirectPage from './OAuthRedirectPage';
 import PostPage from './PostPage';
+import ProductEditPage from './ProductEditPage';
 import SignUpPage from './SignUpPage';
 
 export default function Routes() {
@@ -16,6 +17,8 @@ export default function Routes() {
       <Route path="/error" element={<ErrorPage />} />
       <Route path="/" element={<MainPage />} />
       <Route path="/product/:productId" element={<DetailPage />} />
+      <Route path="/product/edit/:productId" element={<ProductEditPage />} />
+      {/* /product/edit/${productId} */}
       <Route path="/post" element={<PostPage />} />
     </RouterRoutes>
   );

--- a/client/src/queries/useCategory.ts
+++ b/client/src/queries/useCategory.ts
@@ -1,0 +1,4 @@
+import { getCategories } from '@apis/product';
+import { useQuery } from '@tanstack/react-query';
+
+export const useCategory = () => useQuery(['category'], getCategories);

--- a/server/src/product/repository/product.repository.ts
+++ b/server/src/product/repository/product.repository.ts
@@ -79,7 +79,12 @@ export class ProductRepository {
     try {
       return this.repository.findOne({
         where: { id },
-        relations: ['region', 'seller.regions.region', 'likedUsers'],
+        relations: [
+          'region',
+          'category',
+          'seller.regions.region',
+          'likedUsers',
+        ],
       });
     } catch (e) {
       throw new HttpException(


### PR DESCRIPTION
## 작업내용 요약
- product update api와 클라이언트 단을 구현했습니다. 
- 추가로 서버에서 가져온 카테고리를 추가하는 로직을 작성했습니다. 

## 작업의도
- product:productId 에서 category를 가져오지않아 relation에 추가했습니다. (categoryId만 받아오는 방법 없을까요?)
- 수정창에 접속하면 곧바로 product를 가져오고 값들이 있으면 form에 등록하고 validation을 미리  진행한다. 

## 관련이슈

- #45 
