### PR TITLE
Feat/43 productutil (상품 상세페이지에서 상태변경 기능, 찜 기능 추가)

### DIFF
--- a/client/src/apis/myAxios.ts
+++ b/client/src/apis/myAxios.ts
@@ -30,7 +30,9 @@ myAxios.interceptors.response.use(
 async function reissueTokenAndRetryRequest(originalRequest: any) {
   const { data: accessToken } = await axios.get('/auth/resign');
   myAxios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
-  return myAxios(originalRequest);
+  const retryingRequest = { ...originalRequest };
+  retryingRequest.headers.Authorization = `Bearer ${accessToken}`;
+  return axios(retryingRequest);
 }
 
 export default myAxios;

--- a/client/src/apis/product.ts
+++ b/client/src/apis/product.ts
@@ -1,10 +1,6 @@
 import { Category } from '@customTypes/category';
-import {
-  CreateProductAPIDto,
-  GetRegionProductDto,
-  IProduct,
-  PatchProductDto,
-} from '@customTypes/product';
+import { PagedResponseDto } from '@customTypes/common';
+import { CreateProductAPIDto, IProduct, IProductItem, PatchProductDto } from '@customTypes/product';
 import myAxios from './myAxios';
 
 interface GetRegionProductsProps {
@@ -18,7 +14,7 @@ export async function getRegionProducts(queryConfig: GetRegionProductsProps) {
     (query, [key, value]) => (value ? `${query}&${key}=${value}` : query),
     '',
   );
-  const { data } = await myAxios.get<GetRegionProductDto>(`/products?${queryString}`);
+  const { data } = await myAxios.get<PagedResponseDto<IProductItem>>(`/products?${queryString}`);
   return data;
 }
 

--- a/client/src/apis/product.ts
+++ b/client/src/apis/product.ts
@@ -20,3 +20,9 @@ export async function getProductDetail(productId?: number) {
     throw new Error('상품 조회에 실패했습니다.');
   }
 }
+
+export async function toggleLike(productId?: number) {
+  if (!productId) throw new Error('상품이 존재하지 않습니다.');
+  const { data: result } = await myAxios.patch(`/products/like/${productId}`);
+  return result.ok;
+}

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -1,6 +1,5 @@
 import { IOAuthUserInfo } from '@customTypes/auth';
-import { IRegion } from '@customTypes/region';
-import { CheckDuplicatedResponseDto, LoginAPIResponseDto } from '@customTypes/user';
+import { CheckDuplicatedResponseDto, IUser, LoginResponseDto } from '@customTypes/user';
 import { makeQueryString } from '@utils/queryParser';
 import axios from 'axios';
 import myAxios from './myAxios';
@@ -29,7 +28,7 @@ export const requestSignUp = async ({ name, regionId, oAuthInfo }: SignUpRequest
 };
 
 export const requestLogin = async (code: string, oAuthOrigin: string) => {
-  const { data: loginResponse } = await myAxios.post<LoginAPIResponseDto>('/auth/login', {
+  const { data: loginResponse } = await myAxios.post<LoginResponseDto>('/auth/login', {
     code,
     oAuthOrigin,
   });
@@ -41,19 +40,7 @@ export const requestResignToken = async () => {
   return accessToken;
 };
 
-interface ILoginUserRegion {
-  regionId: number;
-  userId: number;
-  region: IRegion;
-}
-
-interface GetLoginUserApiDto {
-  id: number;
-  name: string;
-  regions: ILoginUserRegion[];
-}
-
 export const getUser = async () => {
-  const { data: user } = await myAxios.get<GetLoginUserApiDto>('/auth/user');
+  const { data: user } = await myAxios.get<IUser>('/auth/user');
   return user;
 };

--- a/client/src/components/LikeButton/index.tsx
+++ b/client/src/components/LikeButton/index.tsx
@@ -1,4 +1,3 @@
-import { toggleLike } from '@apis/product';
 import HeartIcon from '@assets/icons/HeartIcon';
 import colors from '@constants/colors';
 import { ILikedUser } from '@customTypes/product';
@@ -7,19 +6,14 @@ import styled, { css } from 'styled-components';
 import { useUser } from '@queries/useUser';
 import useLikeButton from './useLikeButton';
 
-interface IInfiniteProductIdx {
-  pageIdx: number;
-  productIdx: number;
-}
-
 interface LikeButtonProps {
   productId: number;
   likedUsers: ILikedUser[];
-  idx: IInfiniteProductIdx;
+  queryKey: (string | number)[];
 }
-export default function LikeButton({ productId, likedUsers, idx }: LikeButtonProps) {
+export default function LikeButton({ productId, likedUsers, queryKey }: LikeButtonProps) {
   const user = useUser();
-  const likeButtonmutator = useLikeButton(productId, idx, user.id);
+  const likeButtonmutator = useLikeButton({ productId, queryKey });
 
   const checkUserPick = (userId: number) =>
     likedUsers.some((likedUser) => likedUser.userId === userId);

--- a/client/src/components/LikeButton/index.tsx
+++ b/client/src/components/LikeButton/index.tsx
@@ -5,37 +5,32 @@ import { ILikedUser } from '@customTypes/product';
 import React, { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useUser } from '@queries/useUser';
+import useLikeButton from './useLikeButton';
+
+interface IInfiniteProductIdx {
+  pageIdx: number;
+  productIdx: number;
+}
 
 interface LikeButtonProps {
   productId: number;
   likedUsers: ILikedUser[];
+  idx: IInfiniteProductIdx;
 }
-export default function LikeButton({ productId, likedUsers }: LikeButtonProps) {
+export default function LikeButton({ productId, likedUsers, idx }: LikeButtonProps) {
   const user = useUser();
-  const [isUserPick, setIsUserPick] = useState(false);
+  const likeButtonmutator = useLikeButton(productId, idx, user.id);
 
-  useEffect(() => {
-    setIsUserPick(isUserInLikerList(user?.id));
-  }, [user]);
-
-  const isUserInLikerList = (userId?: number) => {
-    if (!userId) return false;
-    const likerList = likedUsers.map((likedUser) => likedUser.userId);
-    return likerList.includes(userId);
-  };
+  const checkUserPick = (userId: number) =>
+    likedUsers.some((likedUser) => likedUser.userId === userId);
 
   const handleLikeButtonClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    try {
-      await toggleLike(productId);
-      setIsUserPick((prev) => !prev);
-    } catch (e) {
-      alert('정상처리되지 않았습니다.');
-    }
+    likeButtonmutator();
   };
 
   return (
-    <LikeButtonWrapper isUserPick={isUserPick} onClick={handleLikeButtonClick}>
+    <LikeButtonWrapper isUserPick={checkUserPick(user.id)} onClick={handleLikeButtonClick}>
       <HeartIcon />
     </LikeButtonWrapper>
   );

--- a/client/src/components/LikeButton/index.tsx
+++ b/client/src/components/LikeButton/index.tsx
@@ -1,24 +1,20 @@
 import HeartIcon from '@assets/icons/HeartIcon';
 import colors from '@constants/colors';
-import { ILikedUser } from '@customTypes/product';
-import React, { useState } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 import { useUser } from '@queries/useUser';
+import { useProduct } from '@queries/useProduct';
 import useLikeButton from './useLikeButton';
 
 interface LikeButtonProps {
   productId: number;
-  likedUsers: ILikedUser[];
 }
-export default function LikeButton({ productId, likedUsers }: LikeButtonProps) {
+export default function LikeButton({ productId }: LikeButtonProps) {
   const user = useUser();
+  const { data: product } = useProduct(productId);
+  const likedUsers = product?.likedUsers || [];
   const isUserPick = likedUsers.some((likedUser) => likedUser.userId === user.id);
-  const [isFilled, setIsFilled] = useState(isUserPick);
-
-  const mutateLikeButton = useLikeButton({
-    productId,
-    toggleLikeView: () => setIsFilled((prev) => !prev),
-  });
+  const mutateLikeButton = useLikeButton({ productId });
 
   const handleLikeButtonClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -26,19 +22,19 @@ export default function LikeButton({ productId, likedUsers }: LikeButtonProps) {
   };
 
   return (
-    <LikeButtonWrapper isFilled={isFilled} onClick={handleLikeButtonClick}>
+    <LikeButtonWrapper isUserPick={isUserPick} onClick={handleLikeButtonClick}>
       <HeartIcon />
     </LikeButtonWrapper>
   );
 }
 
-const LikeButtonWrapper = styled.button<{ isFilled: boolean }>`
+const LikeButtonWrapper = styled.button<{ isUserPick: boolean }>`
   svg {
     scale: 1.2;
     stroke-width: 2;
     stroke: ${colors.grey1};
-    ${({ isFilled }) =>
-      isFilled &&
+    ${({ isUserPick }) =>
+      isUserPick &&
       css`
         fill: ${colors.primary};
       `}

--- a/client/src/components/LikeButton/index.tsx
+++ b/client/src/components/LikeButton/index.tsx
@@ -1,7 +1,7 @@
 import HeartIcon from '@assets/icons/HeartIcon';
 import colors from '@constants/colors';
 import { ILikedUser } from '@customTypes/product';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 import { useUser } from '@queries/useUser';
 import useLikeButton from './useLikeButton';

--- a/client/src/components/LikeButton/index.tsx
+++ b/client/src/components/LikeButton/index.tsx
@@ -1,7 +1,7 @@
 import HeartIcon from '@assets/icons/HeartIcon';
 import colors from '@constants/colors';
 import { ILikedUser } from '@customTypes/product';
-import React from 'react';
+import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useUser } from '@queries/useUser';
 import useLikeButton from './useLikeButton';
@@ -9,34 +9,36 @@ import useLikeButton from './useLikeButton';
 interface LikeButtonProps {
   productId: number;
   likedUsers: ILikedUser[];
-  queryKey: (string | number)[];
 }
-export default function LikeButton({ productId, likedUsers, queryKey }: LikeButtonProps) {
+export default function LikeButton({ productId, likedUsers }: LikeButtonProps) {
   const user = useUser();
-  const likeButtonmutator = useLikeButton({ productId, queryKey });
+  const isUserPick = likedUsers.some((likedUser) => likedUser.userId === user.id);
+  const [isFilled, setIsFilled] = useState(isUserPick);
 
-  const checkUserPick = (userId: number) =>
-    likedUsers.some((likedUser) => likedUser.userId === userId);
+  const mutateLikeButton = useLikeButton({
+    productId,
+    toggleLikeView: () => setIsFilled((prev) => !prev),
+  });
 
   const handleLikeButtonClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    likeButtonmutator();
+    mutateLikeButton();
   };
 
   return (
-    <LikeButtonWrapper isUserPick={checkUserPick(user.id)} onClick={handleLikeButtonClick}>
+    <LikeButtonWrapper isFilled={isFilled} onClick={handleLikeButtonClick}>
       <HeartIcon />
     </LikeButtonWrapper>
   );
 }
 
-const LikeButtonWrapper = styled.button<{ isUserPick: boolean }>`
+const LikeButtonWrapper = styled.button<{ isFilled: boolean }>`
   svg {
     scale: 1.2;
     stroke-width: 2;
     stroke: ${colors.grey1};
-    ${({ isUserPick }) =>
-      isUserPick &&
+    ${({ isFilled }) =>
+      isFilled &&
       css`
         fill: ${colors.primary};
       `}

--- a/client/src/components/LikeButton/useLikeButton.tsx
+++ b/client/src/components/LikeButton/useLikeButton.tsx
@@ -1,0 +1,43 @@
+import { toggleLike } from '@apis/product';
+import { IProduct } from '@customTypes/product';
+import { UseMutateFunction, useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface IProductIdx {
+  pageIdx: number;
+  productIdx: number;
+}
+
+export default function useLikeButton(
+  productId: number,
+  idx: IProductIdx,
+  userId?: number,
+): UseMutateFunction<void, unknown, void, unknown> {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation(() => toggleLike(productId), {
+    onMutate: () => {
+      // eslint-disable-next-line no-debugger
+      debugger;
+      const queryKey = ['products', productId];
+      const snapshot = queryClient.getQueryData<IProduct[][]>(queryKey);
+      if (!userId) return snapshot;
+      console.log(snapshot);
+      queryClient.setQueryData<IProduct[][]>(queryKey, (productPages) => {
+        if (!productPages) return [];
+        productPages[idx.pageIdx][idx.productIdx].likedUsers.push({
+          productId,
+          userId,
+        });
+        console.log(productPages);
+        return { ...productPages };
+      });
+      return snapshot;
+    },
+
+    onSuccess: () => {
+      queryClient.invalidateQueries(['products', String(productId)]);
+    },
+  });
+
+  return mutate;
+}

--- a/client/src/components/LikeButton/useLikeButton.tsx
+++ b/client/src/components/LikeButton/useLikeButton.tsx
@@ -3,13 +3,7 @@ import { PagedResponseDto, QueryKeyType } from '@customTypes/common';
 import { IProductItem } from '@customTypes/product';
 import { useProduct } from '@queries/useProduct';
 import { useUser } from '@queries/useUser';
-import {
-  InfiniteData,
-  UseMutateFunction,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query';
+import { UseMutateFunction, useMutation, useQueryClient } from '@tanstack/react-query';
 
 interface UseLikeButtonprops {
   productId: number;

--- a/client/src/components/LikeButton/useLikeButton.tsx
+++ b/client/src/components/LikeButton/useLikeButton.tsx
@@ -26,6 +26,16 @@ export default function useLikeButton({
       const snapshot = queryClient.getQueryData<InfiniteData<GetRegionProductDto>>(queryKey);
       queryClient.setQueryData<InfiniteData<GetRegionProductDto>>(queryKey, (infinitePages) => {
         if (!infinitePages) return infinitePages;
+        // const products = infinitePages.pages.map((page) => page.products).flat();
+        // const targetProductIdx = products.findIndex((product) => product.id === productId);
+        // const targetProduct = products[targetProductIdx];
+        // if (!targetProduct) throw new Error('상품이 존재하지 않습니다.');
+        // const isAlreadyLiked = targetProduct.likedUsers.find(({ userId }) => userId === user.id);
+        // const toggledProduct = { ...targetProduct };
+        // toggledProduct.likedUsers.push({ userId: user.id, productId });
+        // products[targetProductIdx] = toggledProduct;
+
+        // todo: 개선필요
         const a = infinitePages.pages.map((productPage) => ({
           ...productPage,
           products: productPage.products.map((product) => {

--- a/client/src/components/LikeButton/useLikeButton.tsx
+++ b/client/src/components/LikeButton/useLikeButton.tsx
@@ -1,35 +1,50 @@
-import { toggleLike } from '@apis/product';
-import { IProduct } from '@customTypes/product';
-import { UseMutateFunction, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getRegionProducts, toggleLike } from '@apis/product';
+import { QueryKeyType } from '@customTypes/common';
+import { GetRegionProductDto, IProduct, IProductItem } from '@customTypes/product';
+import { useUser } from '@queries/useUser';
+import {
+  InfiniteData,
+  UseMutateFunction,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
 
-interface IProductIdx {
-  pageIdx: number;
-  productIdx: number;
+interface UseLikeButtonprops {
+  productId: number;
+  queryKey: QueryKeyType;
 }
 
-export default function useLikeButton(
-  productId: number,
-  idx: IProductIdx,
-  userId?: number,
-): UseMutateFunction<void, unknown, void, unknown> {
+export default function useLikeButton({
+  productId,
+  queryKey,
+}: UseLikeButtonprops): UseMutateFunction<void, unknown, void, unknown> {
   const queryClient = useQueryClient();
+  const user = useUser();
 
   const { mutate } = useMutation(() => toggleLike(productId), {
     onMutate: () => {
-      // eslint-disable-next-line no-debugger
-      debugger;
-      const queryKey = ['products', productId];
-      const snapshot = queryClient.getQueryData<IProduct[][]>(queryKey);
-      if (!userId) return snapshot;
-      console.log(snapshot);
-      queryClient.setQueryData<IProduct[][]>(queryKey, (productPages) => {
-        if (!productPages) return [];
-        productPages[idx.pageIdx][idx.productIdx].likedUsers.push({
-          productId,
-          userId,
-        });
-        console.log(productPages);
-        return { ...productPages };
+      const snapshot = queryClient.getQueryData<InfiniteData<GetRegionProductDto>>(queryKey);
+      queryClient.setQueryData<InfiniteData<GetRegionProductDto>>(queryKey, (infinitePages) => {
+        if (!infinitePages) return infinitePages;
+        const a = infinitePages.pages.map((productPage) => ({
+          ...productPage,
+          products: productPage.products.map((product) => {
+            if (product.id === productId) {
+              // 만약 likedUser가 없으면 넣어주고 있으면 빼준다.
+              const isLiked = product.likedUsers.find(({ userId }) => userId === user.id);
+              const newProduct: IProductItem = {
+                ...product,
+                likedUsers: isLiked
+                  ? product.likedUsers.filter((likedUser) => likedUser.userId !== user.id)
+                  : [...product.likedUsers, { userId: user.id, productId }],
+              };
+
+              return newProduct;
+            }
+            return product;
+          }),
+        }));
+        return { ...infinitePages, pages: a };
       });
       return snapshot;
     },

--- a/client/src/components/LikeButton/useLikeButton.tsx
+++ b/client/src/components/LikeButton/useLikeButton.tsx
@@ -1,25 +1,20 @@
 import { toggleLike } from '@apis/product';
-import { PagedResponseDto, QueryKeyType } from '@customTypes/common';
 import { IProductItem } from '@customTypes/product';
 import { useProduct } from '@queries/useProduct';
-import { useUser } from '@queries/useUser';
 import { UseMutateFunction, useMutation, useQueryClient } from '@tanstack/react-query';
 
 interface UseLikeButtonprops {
   productId: number;
-  toggleLikeView: () => void;
 }
 
 export default function useLikeButton({
   productId,
-  toggleLikeView,
 }: UseLikeButtonprops): UseMutateFunction<void, unknown, void, unknown> {
   const queryClient = useQueryClient();
   const { refetch } = useProduct(productId);
   const { mutate } = useMutation(() => toggleLike(productId), {
     onMutate: () => {
       const snapshot = queryClient.getQueryData<IProductItem>(['prduct', productId]);
-      toggleLikeView();
       return { snapshot };
     },
 

--- a/client/src/components/LikeButton/useLikeButton.tsx
+++ b/client/src/components/LikeButton/useLikeButton.tsx
@@ -1,6 +1,6 @@
 import { getRegionProducts, toggleLike } from '@apis/product';
-import { QueryKeyType } from '@customTypes/common';
-import { GetRegionProductDto, IProduct, IProductItem } from '@customTypes/product';
+import { PagedResponseDto, QueryKeyType } from '@customTypes/common';
+import { IProduct, IProductItem } from '@customTypes/product';
 import { useUser } from '@queries/useUser';
 import {
   InfiniteData,
@@ -23,44 +23,41 @@ export default function useLikeButton({
 
   const { mutate } = useMutation(() => toggleLike(productId), {
     onMutate: () => {
-      const snapshot = queryClient.getQueryData<InfiniteData<GetRegionProductDto>>(queryKey);
-      queryClient.setQueryData<InfiniteData<GetRegionProductDto>>(queryKey, (infinitePages) => {
-        if (!infinitePages) return infinitePages;
-        // const products = infinitePages.pages.map((page) => page.products).flat();
-        // const targetProductIdx = products.findIndex((product) => product.id === productId);
-        // const targetProduct = products[targetProductIdx];
-        // if (!targetProduct) throw new Error('상품이 존재하지 않습니다.');
-        // const isAlreadyLiked = targetProduct.likedUsers.find(({ userId }) => userId === user.id);
-        // const toggledProduct = { ...targetProduct };
-        // toggledProduct.likedUsers.push({ userId: user.id, productId });
-        // products[targetProductIdx] = toggledProduct;
+      const snapshot =
+        queryClient.getQueryData<InfiniteData<PagedResponseDto<IProductItem>>>(queryKey);
+      queryClient.setQueryData<InfiniteData<PagedResponseDto<IProductItem>>>(
+        queryKey,
+        (infinitePages) => {
+          if (!infinitePages) return infinitePages;
 
-        // todo: 개선필요
-        const a = infinitePages.pages.map((productPage) => ({
-          ...productPage,
-          products: productPage.products.map((product) => {
-            if (product.id === productId) {
-              // 만약 likedUser가 없으면 넣어주고 있으면 빼준다.
-              const isLiked = product.likedUsers.find(({ userId }) => userId === user.id);
-              const newProduct: IProductItem = {
-                ...product,
-                likedUsers: isLiked
-                  ? product.likedUsers.filter((likedUser) => likedUser.userId !== user.id)
-                  : [...product.likedUsers, { userId: user.id, productId }],
-              };
+          // todo: 개선필요
+          const newPages = infinitePages.pages.map((productPage) => ({
+            ...productPage,
+            products: productPage.data.map((product) => {
+              if (product.id === productId) {
+                // 만약 likedUser가 없으면 넣어주고 있으면 빼준다.
+                const isLiked = product.likedUsers.find(({ userId }) => userId === user.id);
+                const newProduct: IProductItem = {
+                  ...product,
+                  likedUsers: isLiked
+                    ? product.likedUsers.filter((likedUser) => likedUser.userId !== user.id)
+                    : [...product.likedUsers, { userId: user.id, productId }],
+                };
 
-              return newProduct;
-            }
-            return product;
-          }),
-        }));
-        return { ...infinitePages, pages: a };
-      });
-      return snapshot;
+                return newProduct;
+              }
+              return product;
+            }),
+          }));
+          return { ...infinitePages, pages: newPages };
+        },
+      );
+
+      return { snapshot };
     },
 
-    onSuccess: () => {
-      queryClient.invalidateQueries(['products', String(productId)]);
+    onError: (error, variables, context) => {
+      queryClient.setQueryData(queryKey, context?.snapshot);
     },
   });
 

--- a/client/src/components/MainPageNavigationBar/MainNavTitle.tsx
+++ b/client/src/components/MainPageNavigationBar/MainNavTitle.tsx
@@ -1,5 +1,4 @@
 import MapPinIcon from '@assets/icons/MapPinIcon';
-import LoadingIndicator from '@components/common/LoadingIndicator';
 import { Text } from '@components/common/Text';
 import colors from '@constants/colors';
 import mixin from '@style/mixin';
@@ -9,13 +8,12 @@ import styled from 'styled-components';
 
 export default function MainNavTitle() {
   const user = useUser();
-  return user ? (
+  const primaryRegion = user.regions[0];
+  return (
     <Container>
       <MapPinIcon />
-      <Text>{getLastAddress(user.regions[0].region.address)}</Text>
+      <Text>{getLastAddress(primaryRegion.address)}</Text>
     </Container>
-  ) : (
-    <LoadingIndicator />
   );
 }
 

--- a/client/src/components/MainPageNavigationBar/MainNavTitle.tsx
+++ b/client/src/components/MainPageNavigationBar/MainNavTitle.tsx
@@ -1,15 +1,14 @@
-import { getUser } from '@apis/user';
 import MapPinIcon from '@assets/icons/MapPinIcon';
 import LoadingIndicator from '@components/common/LoadingIndicator';
 import { Text } from '@components/common/Text';
 import colors from '@constants/colors';
 import mixin from '@style/mixin';
-import { useQuery } from '@tanstack/react-query';
 import { getLastAddress } from '@utils/product';
+import { useUser } from '@queries/useUser';
 import styled from 'styled-components';
 
 export default function MainNavTitle() {
-  const { data: user } = useQuery(['user'], getUser);
+  const user = useUser();
   return user ? (
     <Container>
       <MapPinIcon />

--- a/client/src/components/ProductItem/index.tsx
+++ b/client/src/components/ProductItem/index.tsx
@@ -13,7 +13,7 @@ import styled from 'styled-components';
 
 interface ProductItemProps {
   productInfo: IProductItem;
-  UtilButton?: React.ReactNode;
+  UtilButton: React.ReactNode;
 }
 
 export default function ProductItem({ productInfo, UtilButton }: ProductItemProps) {

--- a/client/src/components/ProductItem/index.tsx
+++ b/client/src/components/ProductItem/index.tsx
@@ -1,9 +1,10 @@
 import Caption from '@components/common/Caption';
 import CountIndicator from '@components/common/CountIndicator';
+import LoadingIndicator from '@components/common/LoadingIndicator';
 import { Text } from '@components/common/Text';
 import Thumbnail from '@components/common/Thumbnail';
 import colors from '@constants/colors';
-import { IProductItem } from '@customTypes/product';
+import { useProduct } from '@queries/useProduct';
 import mixin from '@style/mixin';
 import { getPassedTimeString } from '@utils/common';
 import { getLastAddress, getPriceString } from '@utils/product';
@@ -12,21 +13,24 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 interface ProductItemProps {
-  productInfo: IProductItem;
+  productId: number;
   UtilButton: React.ReactNode;
 }
 
-export default function ProductItem({ productInfo, UtilButton }: ProductItemProps) {
+export default function ProductItem({ productId, UtilButton }: ProductItemProps) {
   const navigate = useNavigate();
+  const { data: product } = useProduct(productId);
+
+  if (!product) return <LoadingIndicator />;
 
   const moveToDetailPage = () => {
-    navigate(`/product/${productInfo.id}`);
+    navigate(`/product/${product.id}`);
   };
 
-  const { thumbnail, name, region, createdAt, price, likedUsers } = productInfo;
+  const { thumbnails, name, region, createdAt, price, likedUsers } = product;
   return (
     <Container onClick={moveToDetailPage}>
-      <Thumbnail src={thumbnail} size="medium" />
+      <Thumbnail src={thumbnails[0]} size="medium" />
       <ProductInfoContainer>
         <Text size="large" weight="bold">
           {name}

--- a/client/src/components/SaleStateSelector/index.tsx
+++ b/client/src/components/SaleStateSelector/index.tsx
@@ -1,22 +1,34 @@
+import { updateProduct } from '@apis/product';
 import ChevronDown from '@assets/icons/ChevronDown';
 import DropDown from '@components/common/DropDown';
 import { Text } from '@components/common/Text';
 import colors from '@constants/colors';
 import { SalesStatusType, SalesStatusEnum } from '@customTypes/product';
 import mixin from '@style/mixin';
+import { useMutation } from '@tanstack/react-query';
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import useSalesStatusSelector from './useSalesStatusSelector';
 
 interface SaleStateSelectorProps {
   initialStatus: SalesStatusType;
+  productId: number;
 }
 
-export default function SaleStateSelector({ initialStatus }: SaleStateSelectorProps) {
+export default function SaleStateSelector({ initialStatus, productId }: SaleStateSelectorProps) {
   const [isDropDownOpen, setIsDropDownOpen] = useState(false);
   const [salesStatus, setSalesStatus] = useState<SalesStatusType>(initialStatus);
+  const salesStatusMutator = useSalesStatusSelector(productId);
+
+  const handleDropDownItemClick = (newSalesStatus: SalesStatusType) => {
+    if (salesStatus === newSalesStatus) return;
+    setSalesStatus(newSalesStatus);
+    salesStatusMutator(newSalesStatus);
+  };
+
   const dropDownItems = Object.entries(SalesStatusEnum).map(([enumKey, enumValue]) => ({
     name: enumValue,
-    onClick: () => setSalesStatus(enumKey as SalesStatusType),
+    onClick: () => handleDropDownItemClick(enumKey as SalesStatusType),
   }));
 
   return (

--- a/client/src/components/SaleStateSelector/useSalesStatusSelector.tsx
+++ b/client/src/components/SaleStateSelector/useSalesStatusSelector.tsx
@@ -1,0 +1,20 @@
+import { updateProduct } from '@apis/product';
+import { SalesStatusType } from '@customTypes/product';
+import { useMutation, UseMutateFunction, useQueryClient } from '@tanstack/react-query';
+
+export default function useSalesStatusSelector(
+  productId: number,
+): UseMutateFunction<void, unknown, SalesStatusType, unknown> {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation(
+    (newSalesStatus: SalesStatusType) => updateProduct({ salesStatus: newSalesStatus }, productId),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['product', String(productId)]);
+      },
+    },
+  );
+
+  return mutate;
+}

--- a/client/src/components/common/LikeButton.tsx
+++ b/client/src/components/common/LikeButton.tsx
@@ -1,9 +1,10 @@
+import { toggleLike } from '@apis/product';
 import { getUser } from '@apis/user';
 import HeartIcon from '@assets/icons/HeartIcon';
 import colors from '@constants/colors';
 import { ILikedUser } from '@customTypes/product';
 import { useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 
 interface LikeButtonProps {
@@ -11,11 +12,31 @@ interface LikeButtonProps {
   likedUsers: ILikedUser[];
 }
 export default function LikeButton({ productId, likedUsers }: LikeButtonProps) {
-  // const { data: user } = useQuery(['user'], getUser);
-  // const [isUserPick, setIsUserPick] = useState(false);
+  const { data: user } = useQuery(['user'], getUser);
+  const [isUserPick, setIsUserPick] = useState(false);
+
+  useEffect(() => {
+    setIsUserPick(isUserInLikerList(user?.id));
+  }, [user]);
+
+  const isUserInLikerList = (userId?: number) => {
+    if (!userId) return false;
+    const likerList = likedUsers.map((likedUser) => likedUser.userId);
+    return likerList.includes(userId);
+  };
+
+  const handleLikeButtonClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    try {
+      await toggleLike(productId);
+      setIsUserPick((prev) => !prev);
+    } catch (e) {
+      alert('정상처리되지 않았습니다.');
+    }
+  };
 
   return (
-    <LikeButtonWrapper isUserPick={false}>
+    <LikeButtonWrapper isUserPick={isUserPick} onClick={handleLikeButtonClick}>
       <HeartIcon />
     </LikeButtonWrapper>
   );

--- a/client/src/components/common/LikeButton.tsx
+++ b/client/src/components/common/LikeButton.tsx
@@ -1,6 +1,8 @@
+import { getUser } from '@apis/user';
 import HeartIcon from '@assets/icons/HeartIcon';
 import colors from '@constants/colors';
 import { ILikedUser } from '@customTypes/product';
+import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import styled, { css } from 'styled-components';
 
@@ -8,9 +10,9 @@ interface LikeButtonProps {
   productId: number;
   likedUsers: ILikedUser[];
 }
-
 export default function LikeButton({ productId, likedUsers }: LikeButtonProps) {
-  //   const [isUserPick, setIsUserPick] = useState(false);
+  // const { data: user } = useQuery(['user'], getUser);
+  // const [isUserPick, setIsUserPick] = useState(false);
 
   return (
     <LikeButtonWrapper isUserPick={false}>

--- a/client/src/components/common/LikeButton.tsx
+++ b/client/src/components/common/LikeButton.tsx
@@ -1,18 +1,17 @@
 import { toggleLike } from '@apis/product';
-import { getUser } from '@apis/user';
 import HeartIcon from '@assets/icons/HeartIcon';
 import colors from '@constants/colors';
 import { ILikedUser } from '@customTypes/product';
-import { useQuery } from '@tanstack/react-query';
 import React, { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
+import { useUser } from '@queries/useUser';
 
 interface LikeButtonProps {
   productId: number;
   likedUsers: ILikedUser[];
 }
 export default function LikeButton({ productId, likedUsers }: LikeButtonProps) {
-  const { data: user } = useQuery(['user'], getUser);
+  const user = useUser();
   const [isUserPick, setIsUserPick] = useState(false);
 
   useEffect(() => {

--- a/client/src/customTypes/common.ts
+++ b/client/src/customTypes/common.ts
@@ -3,3 +3,16 @@ export interface InfiniteFetchFunctionDto {
 }
 
 export type QueryKeyType = (string | number)[];
+
+export interface Data {
+  id: number;
+}
+
+export interface PagedResponseDto<T extends Data> {
+  nextStartParam: number | null;
+  data: T[];
+}
+
+interface IFetchFunction {
+  nextStartParam: number | null;
+}

--- a/client/src/customTypes/common.ts
+++ b/client/src/customTypes/common.ts
@@ -1,3 +1,5 @@
 export interface InfiniteFetchFunctionDto {
   nextStartParam: number | null;
 }
+
+export type QueryKeyType = (string | number)[];

--- a/client/src/customTypes/product.ts
+++ b/client/src/customTypes/product.ts
@@ -40,10 +40,6 @@ export interface IProductItem
   thumbnail: string;
 }
 
-export interface GetRegionProductDto extends InfiniteFetchFunctionDto {
-  products: IProductItem[];
-}
-
 export interface CreateProductAPIDto {
   name: string;
   price: number;

--- a/client/src/customTypes/product.ts
+++ b/client/src/customTypes/product.ts
@@ -53,4 +53,6 @@ export interface CreateProductAPIDto {
   categoryId: number;
 }
 
-export type PatchProductDto = Partial<CreateProductAPIDto>;
+export interface PatchProductDto extends Partial<CreateProductAPIDto> {
+  salesStatus?: SalesStatusType;
+}

--- a/client/src/customTypes/user.ts
+++ b/client/src/customTypes/user.ts
@@ -7,7 +7,7 @@ export interface IUser {
   regions: IRegion[];
 }
 
-export interface LoginAPIResponseDto {
+export interface LoginResponseDto {
   isRegistered: boolean;
   oAuthInfo?: IOAuthUserInfo;
   accessToken?: string;

--- a/client/src/hooks/useInfiniteScroll.tsx
+++ b/client/src/hooks/useInfiniteScroll.tsx
@@ -1,21 +1,19 @@
+import { Data, PagedResponseDto } from '@customTypes/common';
 import { useUser } from '@queries/useUser';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
-
-interface IFetchFunction {
-  nextStartParam: number | null;
-}
 
 interface UseInfiniteScrollProps<T> {
   queryKey: (string | number | undefined)[];
   fetchFunction: (pageParam?: number) => Promise<T>;
 }
 
-export default function useInfiniteScroll<T extends IFetchFunction>({
+export default function useInfiniteScroll<T extends Data>({
   queryKey,
   fetchFunction,
-}: UseInfiniteScrollProps<T>) {
+}: UseInfiniteScrollProps<PagedResponseDto<T>>) {
   const user = useUser();
+  const queryClinet = useQueryClient();
   const { data, fetchNextPage, isLoading, hasNextPage } = useInfiniteQuery(
     queryKey,
     ({ pageParam = undefined }) => fetchFunction(pageParam),
@@ -24,8 +22,17 @@ export default function useInfiniteScroll<T extends IFetchFunction>({
       getNextPageParam: (lastPage) => lastPage.nextStartParam || undefined,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
+      onSuccess: ({ pages }) => spreadPageDataOnEachKey('product', pages.at(-1)),
     },
   );
+
+  const spreadPageDataOnEachKey = (queryPrefix: string, page?: PagedResponseDto<T>) => {
+    if (!page) return;
+
+    page.data.forEach((dataItem) => {
+      queryClinet.setQueryData([queryPrefix, dataItem.id], dataItem);
+    });
+  };
 
   const observerRef = useRef<IntersectionObserver>();
   const triggerRef = useRef<HTMLDivElement>(null);

--- a/client/src/hooks/useInfiniteScroll.tsx
+++ b/client/src/hooks/useInfiniteScroll.tsx
@@ -1,5 +1,5 @@
-import { getUser } from '@apis/user';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useUser } from '@queries/useUser';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 
 interface IFetchFunction {
@@ -15,7 +15,7 @@ export default function useInfiniteScroll<T extends IFetchFunction>({
   queryKey,
   fetchFunction,
 }: UseInfiniteScrollProps<T>) {
-  const { data: user } = useQuery(['user'], getUser);
+  const user = useUser;
   const { data, fetchNextPage, isLoading, hasNextPage } = useInfiniteQuery(
     queryKey,
     ({ pageParam = undefined }) => fetchFunction(pageParam),

--- a/client/src/hooks/useInfiniteScroll.tsx
+++ b/client/src/hooks/useInfiniteScroll.tsx
@@ -15,12 +15,12 @@ export default function useInfiniteScroll<T extends IFetchFunction>({
   queryKey,
   fetchFunction,
 }: UseInfiniteScrollProps<T>) {
-  const user = useUser;
+  const user = useUser();
   const { data, fetchNextPage, isLoading, hasNextPage } = useInfiniteQuery(
     queryKey,
     ({ pageParam = undefined }) => fetchFunction(pageParam),
     {
-      enabled: !!user,
+      enabled: user.id > 0,
       getNextPageParam: (lastPage) => lastPage.nextStartParam || undefined,
       refetchOnWindowFocus: false,
       refetchOnMount: false,

--- a/client/src/hooks/useLogin.tsx
+++ b/client/src/hooks/useLogin.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { LoginAPIResponseDto } from '@customTypes/user';
+import { LoginResponseDto } from '@customTypes/user';
 import { useQuery } from '@tanstack/react-query';
 import { requestLogin, requestResignToken } from '@apis/user';
 import myAxios from '@apis/myAxios';
@@ -11,7 +11,7 @@ export default function useLogin() {
     myAxios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
   };
 
-  const handleLoginResult = (loginResult: LoginAPIResponseDto, error: unknown) => {
+  const handleLoginResult = (loginResult: LoginResponseDto, error: unknown) => {
     const { isRegistered, oAuthInfo, accessToken } = loginResult;
     if (!isRegistered) {
       navigate('/signUp', { state: { ...oAuthInfo } });
@@ -28,7 +28,7 @@ export default function useLogin() {
   };
 
   const login = async (code: string, oAuthOrigin: string) => {
-    const { data: loginResult, error } = useQuery<LoginAPIResponseDto>(['login'], () =>
+    const { data: loginResult, error } = useQuery<LoginResponseDto>(['login'], () =>
       requestLogin(code, oAuthOrigin),
     );
     if (!loginResult) return;

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -16,18 +16,18 @@ import colors from '@constants/colors';
 import LikeButton from '@components/LikeButton';
 import ChatButton from '@components/ChatButton';
 import { useUser } from '@queries/useUser';
+import { useProduct } from '@queries/useProduct';
 
 export default function DetailPage() {
   const { productId } = useParams();
-  const { data: product } = useQuery(['product', productId], () =>
-    getProductDetail(Number(productId)),
-  );
+  const { data: product } = useProduct(Number(productId));
   const user = useUser();
 
   if (!product) {
     return <LoadingIndicator />;
   }
   const { name, createdAt, region, description, views, likedUsers, seller, id, price } = product;
+  console.log(product);
   return (
     <Container>
       <DetailPageNavigationBar />
@@ -62,7 +62,7 @@ export default function DetailPage() {
         </SellerInfo>
       </DetailPageBody>
       <DetailPageFooter>
-        {/* <LikeButton productId={id} likedUsers={likedUsers} /> */}
+        <LikeButton productId={id} likedUsers={likedUsers} />
         <Text weight="bolder">{getPriceString(price)}</Text>
         <ChatButton />
       </DetailPageFooter>

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -2,7 +2,6 @@ import { useParams } from 'react-router-dom';
 import DetailPageNavigationBar from '@components/DetailPageNavigationBar';
 import { useQuery } from '@tanstack/react-query';
 import { getProductDetail } from '@apis/product';
-import { getUser } from '@apis/user';
 import SaleStateSelector from '@components/SaleStateSelector';
 import LoadingIndicator from '@components/common/LoadingIndicator';
 import ImageSlider from '@components/ImageSlider.tsx';
@@ -16,13 +15,14 @@ import { getPassedTimeString } from '@utils/common';
 import colors from '@constants/colors';
 import LikeButton from '@components/common/LikeButton';
 import ChatButton from '@components/ChatButton';
+import { useUser } from '@queries/useUser';
 
 export default function DetailPage() {
   const { productId } = useParams();
   const { data: product } = useQuery(['product', productId], () =>
     getProductDetail(Number(productId)),
   );
-  const { data: user } = useQuery(['user'], getUser);
+  const user = useUser();
 
   if (!product) {
     return <LoadingIndicator />;

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -13,7 +13,7 @@ import Caption from '@components/common/Caption';
 import { getLastAddress, getPriceString } from '@utils/product';
 import { getPassedTimeString } from '@utils/common';
 import colors from '@constants/colors';
-import LikeButton from '@components/common/LikeButton';
+import LikeButton from '@components/LikeButton';
 import ChatButton from '@components/ChatButton';
 import { useUser } from '@queries/useUser';
 
@@ -33,8 +33,8 @@ export default function DetailPage() {
       <DetailPageNavigationBar />
       <ImageSlider images={['1']} />
       <DetailPageBody>
-        {user?.id === product.seller.id && (
-          <SaleStateSelector initialStatus={product.salesStatus} />
+        {user.id === product.seller.id && (
+          <SaleStateSelector initialStatus={product.salesStatus} productId={id} />
         )}
         <DetailContent>
           <Text size="large" weight="bold">
@@ -62,7 +62,7 @@ export default function DetailPage() {
         </SellerInfo>
       </DetailPageBody>
       <DetailPageFooter>
-        <LikeButton productId={id} likedUsers={likedUsers} />
+        {/* <LikeButton productId={id} likedUsers={likedUsers} /> */}
         <Text weight="bolder">{getPriceString(price)}</Text>
         <ChatButton />
       </DetailPageFooter>

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -27,7 +27,6 @@ export default function DetailPage() {
     return <LoadingIndicator />;
   }
   const { name, createdAt, region, description, views, likedUsers, seller, id, price } = product;
-  console.log(product);
   return (
     <Container>
       <DetailPageNavigationBar />

--- a/client/src/pages/DetailPage.tsx
+++ b/client/src/pages/DetailPage.tsx
@@ -61,7 +61,7 @@ export default function DetailPage() {
         </SellerInfo>
       </DetailPageBody>
       <DetailPageFooter>
-        <LikeButton productId={id} likedUsers={likedUsers} />
+        <LikeButton productId={id} />
         <Text weight="bolder">{getPriceString(price)}</Text>
         <ChatButton />
       </DetailPageFooter>

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,5 +1,4 @@
 import { getRegionProducts } from '@apis/product';
-import { getUser } from '@apis/user';
 import CircleButton from '@components/common/CircleButton';
 import LikeButton from '@components/common/LikeButton';
 import PageContainer from '@components/common/PageContainer';
@@ -8,12 +7,12 @@ import ProductItem from '@components/ProductItem';
 import colors from '@constants/colors';
 import { GetRegionProductDto } from '@customTypes/product';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
-import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { useUser } from '../queries/useUser';
 
 export default function MainPage() {
-  const { data: user } = useQuery(['user'], getUser);
+  const user = useUser();
   const { data, Trigger } = useInfiniteScroll<GetRegionProductDto>({
     queryKey: ['products', user?.regions[0].regionId],
     fetchFunction: (pageParam?: number) =>

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,6 +1,6 @@
 import { getRegionProducts } from '@apis/product';
 import CircleButton from '@components/common/CircleButton';
-import LikeButton from '@components/common/LikeButton';
+import LikeButton from '@components/LikeButton';
 import PageContainer from '@components/common/PageContainer';
 import MainPageNavigationBar from '@components/MainPageNavigationBar';
 import ProductItem from '@components/ProductItem';
@@ -9,27 +9,33 @@ import { GetRegionProductDto } from '@customTypes/product';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import LoadingIndicator from '@components/common/LoadingIndicator';
 import { useUser } from '../queries/useUser';
 
 export default function MainPage() {
   const user = useUser();
+  const primaryRegion = user.regions[0];
   const { data, Trigger } = useInfiniteScroll<GetRegionProductDto>({
-    queryKey: ['products', user?.regions[0].regionId],
+    queryKey: ['products', primaryRegion.id],
     fetchFunction: (pageParam?: number) =>
-      getRegionProducts({ regionId: user?.regions[0].regionId, start: pageParam }),
+      getRegionProducts({ regionId: primaryRegion.id, start: pageParam }),
   });
 
-  return (
+  return user.id > 0 ? (
     <>
       <MainPageNavigationBar />
       <MainPageWrapper>
-        {data?.pages.map((page) =>
-          page.products.map((productInfo) => (
+        {data?.pages.map((page, pageIdx) =>
+          page.products.map((productInfo, productIdx) => (
             <ProductItem
               key={productInfo.id}
               productInfo={productInfo}
               UtilButton={
-                <LikeButton productId={productInfo.id} likedUsers={productInfo.likedUsers} />
+                <LikeButton
+                  productId={productInfo.id}
+                  likedUsers={productInfo.likedUsers}
+                  idx={{ pageIdx, productIdx }}
+                />
               }
             />
           )),
@@ -40,6 +46,8 @@ export default function MainPage() {
         </RegisterNewProductLink>
       </MainPageWrapper>
     </>
+  ) : (
+    <LoadingIndicator />
   );
 }
 

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -9,13 +9,11 @@ import { IProductItem } from '@customTypes/product';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import { useQueryClient } from '@tanstack/react-query';
 import { useUser } from '../queries/useUser';
 
 export default function MainPage() {
   const user = useUser();
   const primaryRegion = user.regions[0];
-  const queryClient = useQueryClient();
   const queryKey = ['products', primaryRegion.id];
   const { data, Trigger } = useInfiniteScroll<IProductItem>({
     queryKey,
@@ -28,23 +26,13 @@ export default function MainPage() {
       <MainPageNavigationBar />
       <MainPageWrapper>
         {data?.pages.map((page) =>
-          page.data.map((product) => {
-            const cachedProduct = queryClient.getQueryData<IProductItem>(['product', product.id]);
-            return (
-              cachedProduct && (
-                <ProductItem
-                  key={cachedProduct.id}
-                  productInfo={cachedProduct}
-                  UtilButton={
-                    <LikeButton
-                      productId={cachedProduct.id}
-                      likedUsers={cachedProduct.likedUsers}
-                    />
-                  }
-                />
-              )
-            );
-          }),
+          page.data.map((product) => (
+            <ProductItem
+              key={product.id}
+              productId={product.id}
+              UtilButton={<LikeButton productId={product.id} likedUsers={product.likedUsers} />}
+            />
+          )),
         )}
         <Trigger />
         <RegisterNewProductLink to="/post">

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -5,7 +5,7 @@ import PageContainer from '@components/common/PageContainer';
 import MainPageNavigationBar from '@components/MainPageNavigationBar';
 import ProductItem from '@components/ProductItem';
 import colors from '@constants/colors';
-import { GetRegionProductDto } from '@customTypes/product';
+import { IProductItem } from '@customTypes/product';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
@@ -15,7 +15,7 @@ export default function MainPage() {
   const user = useUser();
   const primaryRegion = user.regions[0];
   const queryKey = ['products', primaryRegion.id];
-  const { data, Trigger } = useInfiniteScroll<GetRegionProductDto>({
+  const { data, Trigger } = useInfiniteScroll<IProductItem>({
     queryKey,
     fetchFunction: (pageParam?: number) =>
       getRegionProducts({ regionId: primaryRegion.id, start: pageParam }),
@@ -26,7 +26,7 @@ export default function MainPage() {
       <MainPageNavigationBar />
       <MainPageWrapper>
         {data?.pages.map((page) =>
-          page.products.map((productInfo) => (
+          page.data.map((productInfo) => (
             <ProductItem
               key={productInfo.id}
               productInfo={productInfo}

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -30,7 +30,7 @@ export default function MainPage() {
             <ProductItem
               key={product.id}
               productId={product.id}
-              UtilButton={<LikeButton productId={product.id} likedUsers={product.likedUsers} />}
+              UtilButton={<LikeButton productId={product.id} />}
             />
           )),
         )}

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -9,32 +9,32 @@ import { GetRegionProductDto } from '@customTypes/product';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import LoadingIndicator from '@components/common/LoadingIndicator';
 import { useUser } from '../queries/useUser';
 
 export default function MainPage() {
   const user = useUser();
   const primaryRegion = user.regions[0];
+  const queryKey = ['products', primaryRegion.id];
   const { data, Trigger } = useInfiniteScroll<GetRegionProductDto>({
-    queryKey: ['products', primaryRegion.id],
+    queryKey,
     fetchFunction: (pageParam?: number) =>
       getRegionProducts({ regionId: primaryRegion.id, start: pageParam }),
   });
 
-  return user.id > 0 ? (
+  return (
     <>
       <MainPageNavigationBar />
       <MainPageWrapper>
-        {data?.pages.map((page, pageIdx) =>
-          page.products.map((productInfo, productIdx) => (
+        {data?.pages.map((page) =>
+          page.products.map((productInfo) => (
             <ProductItem
               key={productInfo.id}
               productInfo={productInfo}
               UtilButton={
                 <LikeButton
+                  queryKey={queryKey}
                   productId={productInfo.id}
                   likedUsers={productInfo.likedUsers}
-                  idx={{ pageIdx, productIdx }}
                 />
               }
             />
@@ -46,8 +46,6 @@ export default function MainPage() {
         </RegisterNewProductLink>
       </MainPageWrapper>
     </>
-  ) : (
-    <LoadingIndicator />
   );
 }
 

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -31,11 +31,7 @@ export default function MainPage() {
               key={productInfo.id}
               productInfo={productInfo}
               UtilButton={
-                <LikeButton
-                  queryKey={queryKey}
-                  productId={productInfo.id}
-                  likedUsers={productInfo.likedUsers}
-                />
+                <LikeButton productId={productInfo.id} likedUsers={productInfo.likedUsers} />
               }
             />
           )),

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -29,10 +29,9 @@ export default function MainPage() {
             <ProductItem
               key={productInfo.id}
               productInfo={productInfo}
-              UtilButton={LikeButton({
-                productId: productInfo.id,
-                likedUsers: productInfo.likedUsers,
-              })}
+              UtilButton={
+                <LikeButton productId={productInfo.id} likedUsers={productInfo.likedUsers} />
+              }
             />
           )),
         )}

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -31,10 +31,9 @@ export default function MainPage() {
           <ProductItem
             key={productInfo.id}
             productInfo={productInfo}
-            UtilButton={LikeButton({
-              productId: productInfo.id,
-              likedUsers: productInfo.likedUsers,
-            })}
+            UtilButton={
+              <LikeButton productId={productInfo.id} likedUsers={productInfo.likedUsers} />
+            }
           />
         ))}
         <RegisterNewProductButtonWrapper>

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -9,11 +9,13 @@ import { IProductItem } from '@customTypes/product';
 import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { useQueryClient } from '@tanstack/react-query';
 import { useUser } from '../queries/useUser';
 
 export default function MainPage() {
   const user = useUser();
   const primaryRegion = user.regions[0];
+  const queryClient = useQueryClient();
   const queryKey = ['products', primaryRegion.id];
   const { data, Trigger } = useInfiniteScroll<IProductItem>({
     queryKey,
@@ -26,15 +28,23 @@ export default function MainPage() {
       <MainPageNavigationBar />
       <MainPageWrapper>
         {data?.pages.map((page) =>
-          page.data.map((productInfo) => (
-            <ProductItem
-              key={productInfo.id}
-              productInfo={productInfo}
-              UtilButton={
-                <LikeButton productId={productInfo.id} likedUsers={productInfo.likedUsers} />
-              }
-            />
-          )),
+          page.data.map((product) => {
+            const cachedProduct = queryClient.getQueryData<IProductItem>(['product', product.id]);
+            return (
+              cachedProduct && (
+                <ProductItem
+                  key={cachedProduct.id}
+                  productInfo={cachedProduct}
+                  UtilButton={
+                    <LikeButton
+                      productId={cachedProduct.id}
+                      likedUsers={cachedProduct.likedUsers}
+                    />
+                  }
+                />
+              )
+            );
+          }),
         )}
         <Trigger />
         <RegisterNewProductLink to="/post">

--- a/client/src/pages/PostPage.tsx
+++ b/client/src/pages/PostPage.tsx
@@ -1,5 +1,4 @@
 import { createProduct } from '@apis/product';
-import { getUser } from '@apis/user';
 import NavigationBar from '@components/common/NavigationBar';
 import PageContainer from '@components/common/PageContainer';
 import {
@@ -12,7 +11,7 @@ import RegionFooter from '@components/Post/RegionFooter';
 import { SubmitButton } from '@components/Post/SubmitButton';
 import { padding } from '@constants/padding';
 import { CreateProductAPIDto } from '@customTypes/product';
-import { useQuery } from '@tanstack/react-query';
+import { useUser } from '@queries/useUser';
 import { getNumber } from '@utils/format';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -27,7 +26,7 @@ export default function PostPage() {
 }
 
 function PostForm() {
-  const { data: user } = useQuery(['user'], getUser);
+  const user = useUser();
 
   const { formInputMap } = useFormInputMap();
   const { isAllValidated } = useFormValidationState();

--- a/client/src/pages/PostPage.tsx
+++ b/client/src/pages/PostPage.tsx
@@ -42,7 +42,7 @@ function PostForm() {
     const product = {
       ...formInputMap,
       price: Number(getNumber(formInputMap.price)),
-      regionId: user?.regions[0].regionId,
+      regionId: user.regions[0].id,
     } as CreateProductAPIDto;
 
     try {

--- a/client/src/pages/ProductEditPage.tsx
+++ b/client/src/pages/ProductEditPage.tsx
@@ -1,5 +1,4 @@
 import { getProductDetail, updateProduct } from '@apis/product';
-import { getUser } from '@apis/user';
 import NavigationBar from '@components/common/NavigationBar';
 import PageContainer from '@components/common/PageContainer';
 import {
@@ -12,6 +11,7 @@ import RegionFooter from '@components/Post/RegionFooter';
 import { SubmitButton } from '@components/Post/SubmitButton';
 import { padding } from '@constants/padding';
 import { CreateProductAPIDto } from '@customTypes/product';
+import { useUser } from '@queries/useUser';
 import { useQuery } from '@tanstack/react-query';
 import { getNumber } from '@utils/format';
 import React from 'react';
@@ -27,7 +27,7 @@ export default function ProductEditPage() {
 }
 
 function PostEditForm() {
-  const { data: user } = useQuery(['user'], getUser);
+  const user = useUser();
   const { productId } = useParams();
   const { data: product } = useQuery(['product', productId], () =>
     getProductDetail(Number(productId)),

--- a/client/src/pages/ProductEditPage.tsx
+++ b/client/src/pages/ProductEditPage.tsx
@@ -48,7 +48,7 @@ function PostEditForm() {
       ...formInputMap,
       price: Number(getNumber(formInputMap.price)),
       // region primary구현해야함
-      regionId: user?.regions[0].regionId,
+      regionId: user.regions[0].id,
     } as CreateProductAPIDto;
 
     try {

--- a/client/src/pages/Routes.tsx
+++ b/client/src/pages/Routes.tsx
@@ -18,7 +18,6 @@ export default function Routes() {
       <Route path="/" element={<MainPage />} />
       <Route path="/product/:productId" element={<DetailPage />} />
       <Route path="/product/edit/:productId" element={<ProductEditPage />} />
-      {/* /product/edit/${productId} */}
       <Route path="/post" element={<PostPage />} />
     </RouterRoutes>
   );

--- a/client/src/queries/useProduct.ts
+++ b/client/src/queries/useProduct.ts
@@ -1,0 +1,19 @@
+import myAxios from '@apis/myAxios';
+import { IProduct } from '@customTypes/product';
+import { useQuery } from '@tanstack/react-query';
+
+export async function getProductDetail(productId?: number) {
+  if (!productId) throw new Error('상품이 존재하지 않습니다.');
+  try {
+    const { data: product } = await myAxios.get<IProduct>(`/products/${productId}`);
+    return product;
+  } catch (e) {
+    throw new Error('상품 조회에 실패했습니다.');
+  }
+}
+
+export const useProduct = (productId: number) =>
+  useQuery(['product', productId], () => getProductDetail(Number(productId)), {
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });

--- a/client/src/queries/useProduct.ts
+++ b/client/src/queries/useProduct.ts
@@ -12,7 +12,7 @@ export async function getProductDetail(productId?: number) {
   }
 }
 
-export const useProduct = (productId: number) =>
+export const useProduct = (productId?: number) =>
   useQuery(['product', productId], () => getProductDetail(Number(productId)), {
     refetchOnMount: false,
     refetchOnWindowFocus: false,

--- a/client/src/queries/useUser.ts
+++ b/client/src/queries/useUser.ts
@@ -1,0 +1,9 @@
+import { getUser } from '@apis/user';
+import { useQuery } from '@tanstack/react-query';
+
+export const useUser = () => {
+  const { data } = useQuery(['user'], getUser, {
+    staleTime: 30000,
+  });
+  return data;
+};

--- a/client/src/queries/useUser.ts
+++ b/client/src/queries/useUser.ts
@@ -1,8 +1,14 @@
 import { getUser } from '@apis/user';
 import { useQuery } from '@tanstack/react-query';
 
+const initialUser = {
+  id: -1,
+  name: '',
+  regions: [{ id: -1, address: '' }],
+};
+
 export const useUser = () => {
-  const { data } = useQuery(['user'], getUser, {
+  const { data = initialUser } = useQuery(['user'], getUser, {
     staleTime: 30000,
   });
   return data;

--- a/client/tsconfig.path.json
+++ b/client/tsconfig.path.json
@@ -11,7 +11,8 @@
       "@stores/*": ["./stores/*"],
       "@customTypes/*": ["./customTypes/*"],
       "@assets/*": ["./assets/*"],
-      "@apis/*": ["./apis/*"]
+      "@apis/*": ["./apis/*"],
+      "@queries/*": ["./queries/*"]
     }
   }
 }

--- a/server/src/authentication/authentication.controller.ts
+++ b/server/src/authentication/authentication.controller.ts
@@ -8,6 +8,7 @@ import {
   Get,
 } from '@nestjs/common';
 import { Response, Request } from 'express';
+import extractRegionsFromUserRegions from 'src/util/parseUtil';
 import { UseAuthGuard } from './decorators/use.auth.guard.decorator';
 import { AuthenticationService } from './service/authentication.service';
 
@@ -42,6 +43,8 @@ export class AuthenticationController {
   @UseAuthGuard()
   async getAuthorizedUser(@Res() res: Response, @Req() req: Request) {
     const loginUser = req['user'];
-    return res.status(HttpStatus.OK).json(loginUser);
+    const userRegions = loginUser.regions;
+    const regions = extractRegionsFromUserRegions(userRegions);
+    return res.status(HttpStatus.OK).json({ ...loginUser, regions });
   }
 }

--- a/server/src/authentication/guards/auth.guard.ts
+++ b/server/src/authentication/guards/auth.guard.ts
@@ -19,7 +19,10 @@ export class AuthGuard implements CanActivate {
     const request = context.switchToHttp().getRequest<Request>();
     const authorizationToken = request.headers.authorization;
     if (!authorizationToken) {
-      throw new HttpException('token이 없습니다.', HttpStatus.UNAUTHORIZED);
+      throw new HttpException(
+        'access token이 없습니다.',
+        HttpStatus.UNAUTHORIZED,
+      );
     }
 
     const accessToken = request.headers.authorization

--- a/server/src/authentication/service/token.service.ts
+++ b/server/src/authentication/service/token.service.ts
@@ -44,17 +44,21 @@ export class TokenService {
       });
       return userId;
     } catch (e) {
-      switch (e.message) {
-        case 'INVALID_TOKEN':
-        case 'TOKEN_IS_ARRAY':
-        case 'NO_USER':
+      switch (e.name) {
+        case 'JsonWebTokenError':
+        case 'NotBeforeError':
           throw new HttpException(
             '유효하지 않은 토큰입니다.',
             HttpStatus.UNAUTHORIZED,
           );
-        case 'EXPIRED_TOKEN':
-          throw new HttpException('토큰이 만료되었습니다.', HttpStatus.GONE);
+        case 'TokenExpiredError':
+          throw new HttpException(
+            '토큰이 만료되었습니다.',
+            HttpStatus.UNAUTHORIZED,
+          );
         default:
+          console.log(e);
+          console.log(e.name);
           throw new HttpException(
             '서버 오류입니다.',
             HttpStatus.INTERNAL_SERVER_ERROR,

--- a/server/src/authentication/service/token.service.ts
+++ b/server/src/authentication/service/token.service.ts
@@ -52,10 +52,17 @@ export class TokenService {
             HttpStatus.UNAUTHORIZED,
           );
         case 'TokenExpiredError':
-          throw new HttpException(
-            '토큰이 만료되었습니다.',
-            HttpStatus.UNAUTHORIZED,
-          );
+          if (tokenType === 'access') {
+            throw new HttpException(
+              'Access 토큰이 만료되었습니다.',
+              HttpStatus.UNAUTHORIZED,
+            );
+          } else {
+            throw new HttpException(
+              'Refresh 토큰이 만료되었습니다.',
+              HttpStatus.GONE,
+            );
+          }
         default:
           console.log(e);
           console.log(e.name);

--- a/server/src/authentication/service/token.service.ts
+++ b/server/src/authentication/service/token.service.ts
@@ -64,8 +64,6 @@ export class TokenService {
             );
           }
         default:
-          console.log(e);
-          console.log(e.name);
           throw new HttpException(
             '서버 오류입니다.',
             HttpStatus.INTERNAL_SERVER_ERROR,

--- a/server/src/product/dto/getProductDetail.dto.ts
+++ b/server/src/product/dto/getProductDetail.dto.ts
@@ -1,6 +1,6 @@
 import { User } from 'src/user/entities/user.entity';
 import { Product } from 'src/product/entities/product.entity';
-import { OmitType, PickType } from '@nestjs/mapped-types';
+import { OmitType } from '@nestjs/mapped-types';
 
 class ProductDetailSellerDto extends OmitType(User, ['regions']) {
   regions: {
@@ -9,6 +9,6 @@ class ProductDetailSellerDto extends OmitType(User, ['regions']) {
   }[];
 }
 
-export class GetProductDetailDto extends OmitType(Product, ['seller']) {
+export class GetProductDto extends OmitType(Product, ['seller']) {
   seller: ProductDetailSellerDto;
 }

--- a/server/src/product/product.controller.ts
+++ b/server/src/product/product.controller.ts
@@ -78,7 +78,7 @@ export class ProductController {
       };
     });
     return res.status(HttpStatus.OK).json({
-      products: parsedProducts,
+      data: parsedProducts,
       nextStartParam: nextStartParam || null,
     });
   }

--- a/server/src/product/product.controller.ts
+++ b/server/src/product/product.controller.ts
@@ -54,31 +54,8 @@ export class ProductController {
         categoryId,
         LIMIT,
       );
-
-    const parsedProducts: GetRegionProductAPIDto[] = products.map((product) => {
-      const {
-        id,
-        name,
-        price,
-        region,
-        salesStatus,
-        createdAt,
-        thumbnails,
-        likedUsers,
-      } = product;
-      return {
-        id,
-        name,
-        price,
-        region,
-        salesStatus,
-        createdAt,
-        likedUsers,
-        thumbnail: thumbnails[0],
-      };
-    });
     return res.status(HttpStatus.OK).json({
-      data: parsedProducts,
+      data: products,
       nextStartParam: nextStartParam || null,
     });
   }

--- a/server/src/product/product.controller.ts
+++ b/server/src/product/product.controller.ts
@@ -19,6 +19,7 @@ import { UpdateProductDto } from './dto/updateProductDto';
 import { ProductService } from './product.service';
 
 @Controller('products')
+@UseAuthGuard()
 export class ProductController {
   constructor(private readonly productService: ProductService) {}
 
@@ -33,7 +34,6 @@ export class ProductController {
   }
 
   @Get()
-  @UseAuthGuard()
   async getRegionProducts(
     @Res() res: Response,
     @Query('region-id') regionId: number,
@@ -65,7 +65,6 @@ export class ProductController {
   }
 
   @Delete(':productId')
-  @UseAuthGuard()
   async deleteProduct(
     @Req() req: Request,
     @Res() res: Response,
@@ -77,7 +76,6 @@ export class ProductController {
   }
 
   @Patch('/like/:productId')
-  @UseAuthGuard()
   async toggleLikeState(
     @Req() req: Request,
     @Res() res: Response,
@@ -92,7 +90,6 @@ export class ProductController {
   }
 
   @Post()
-  @UseAuthGuard()
   async createProduct(
     @Res() res: Response,
     @Req() req: Request,
@@ -108,7 +105,6 @@ export class ProductController {
   }
 
   @Patch('/:productId')
-  @UseAuthGuard()
   async updateProduct(
     @Res() res: Response,
     @Req() req: Request,

--- a/server/src/product/product.service.ts
+++ b/server/src/product/product.service.ts
@@ -8,6 +8,7 @@ import { LikeDto } from './dto/like.dto';
 import { GetProductDetailDto } from './dto/getProductDetail.dto';
 import { CategoryRepository } from './repository/category.repository';
 import { Category } from './entities/category.entity';
+import extractRegionsFromUserRegions from 'src/util/parseUtil';
 
 @Injectable()
 export class ProductService {
@@ -76,10 +77,7 @@ export class ProductService {
       seller: { regions: rawSellerRegion, ...sellerData },
       ...restData
     } = await this.getProduct(productId);
-    const parsedSellerRegion = rawSellerRegion.map((rawSellerRegion) => ({
-      id: rawSellerRegion.region.id,
-      address: rawSellerRegion.region.address,
-    }));
+    const parsedSellerRegion = extractRegionsFromUserRegions(rawSellerRegion);
     const parsedProduct: GetProductDetailDto = {
       ...restData,
       seller: { regions: parsedSellerRegion, ...sellerData },

--- a/server/src/product/product.service.ts
+++ b/server/src/product/product.service.ts
@@ -5,7 +5,7 @@ import { Product } from './entities/product.entity';
 import { CreateProductDto } from './dto/createProduct.dto';
 import { UpdateProductDto } from './dto/updateProductDto';
 import { LikeDto } from './dto/like.dto';
-import { GetProductDetailDto } from './dto/getProductDetail.dto';
+import { GetProductDto } from './dto/getProductDetail.dto';
 import { CategoryRepository } from './repository/category.repository';
 import { Category } from './entities/category.entity';
 import extractRegionsFromUserRegions from 'src/util/parseUtil';
@@ -18,24 +18,41 @@ export class ProductService {
     private readonly categoryRepository: CategoryRepository,
   ) {}
 
-  getRegionProducts(regionId: number): Promise<Product[]> {
-    return this.productRepository.findProductsByRegion(regionId);
+  getProduct(productId: number): Promise<Product> {
+    return this.productRepository.findOneByProductId(productId);
   }
 
-  async getPaginationOfProductsByRegion(
+  formatProductForDto(product: Product): GetProductDto {
+    const {
+      seller: { regions: rawSellerRegion, ...sellerData },
+      ...restData
+    } = product;
+    const parsedSellerRegion = extractRegionsFromUserRegions(rawSellerRegion);
+    const parsedProduct: GetProductDto = {
+      ...restData,
+      seller: { regions: parsedSellerRegion, ...sellerData },
+    };
+    return parsedProduct;
+  }
+
+  async getPagedProducts(
     startProductId: number,
     regionId: number,
     categoryId: number,
     limit: number,
   ): Promise<{
-    products: Product[];
+    products: GetProductDto[];
     nextStartParam: number | undefined;
   }> {
-    const products = await this.productRepository.findProductsByRegionWithLimit(
+    const products = await this.productRepository.findProductsWithLimit(
       startProductId,
       limit,
       regionId,
       categoryId,
+    );
+
+    const formattedProducts = products.map((product) =>
+      this.formatProductForDto(product),
     );
 
     const isEnd = products[limit];
@@ -45,7 +62,7 @@ export class ProductService {
       products.pop();
     }
 
-    return { products, nextStartParam };
+    return { products: formattedProducts, nextStartParam };
   }
 
   createNewProduct(createProductDto: CreateProductDto) {
@@ -66,23 +83,6 @@ export class ProductService {
 
   getCategories(): Promise<Category[]> {
     return this.categoryRepository.findAll();
-  }
-
-  getProduct(productId: number): Promise<Product> {
-    return this.productRepository.findOneByProductId(productId);
-  }
-
-  async getAndParseProductDetail(productId: number) {
-    const {
-      seller: { regions: rawSellerRegion, ...sellerData },
-      ...restData
-    } = await this.getProduct(productId);
-    const parsedSellerRegion = extractRegionsFromUserRegions(rawSellerRegion);
-    const parsedProduct: GetProductDetailDto = {
-      ...restData,
-      seller: { regions: parsedSellerRegion, ...sellerData },
-    };
-    return parsedProduct;
   }
 
   async deleteProduct(productId: number, userId: number) {

--- a/server/src/product/repository/product.repository.ts
+++ b/server/src/product/repository/product.repository.ts
@@ -34,7 +34,26 @@ export class ProductRepository {
     }
   }
 
-  public async findProductsByRegionWithLimit(
+  public async findOneByProductId(id: number) {
+    try {
+      return this.repository.findOne({
+        where: { id },
+        relations: [
+          'region',
+          'category',
+          'seller.regions.region',
+          'likedUsers',
+        ],
+      });
+    } catch (e) {
+      throw new HttpException(
+        '존재하지 않는 상품입니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+  }
+
+  public async findProductsWithLimit(
     startProductId: number,
     limit: number,
     regionId: number,
@@ -47,7 +66,7 @@ export class ProductRepository {
         categoryId: categoryId,
       },
       order: { id: 'DESC' },
-      relations: ['region', 'likedUsers'],
+      relations: ['region', 'likedUsers', 'category', 'seller.regions.region'],
       take: limit + 1,
     });
   }
@@ -71,25 +90,6 @@ export class ProductRepository {
       throw new HttpException(
         '상품 업데이트를 실패했습니다.',
         HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
-  }
-
-  public async findOneByProductId(id: number) {
-    try {
-      return this.repository.findOne({
-        where: { id },
-        relations: [
-          'region',
-          'category',
-          'seller.regions.region',
-          'likedUsers',
-        ],
-      });
-    } catch (e) {
-      throw new HttpException(
-        '존재하지 않는 상품입니다.',
-        HttpStatus.NOT_FOUND,
       );
     }
   }

--- a/server/src/util/parseUtil.ts
+++ b/server/src/util/parseUtil.ts
@@ -1,0 +1,12 @@
+import { UserRegion } from 'src/region/entities/userRegion.entity';
+
+export default function extractRegionsFromUserRegions(
+  userRegions: Partial<UserRegion>[],
+) {
+  const regions = userRegions.map((userRegion) => ({
+    id: userRegion.region.id,
+    address: userRegion.region.address,
+  }));
+
+  return regions;
+}


### PR DESCRIPTION
## 작업내용 요약

- 메인페이지에서 하트를 누르면 상품을 찜할 수 있도록 했습니다.
- 상세페이지에서 자신의 판매상품일경우 판매상태를 변경할 수 있도록 했습니다.

## 작업의도

- 하트를 누르는 작업의 경우 이후 추가 작업이 많이 필요합니다.
- 의도는 하트를 누르면 우선 브라우저에 낙관적으로 선반영 후 만약 요청이 실패하면 상태를 되돌리는 것인데 아직 구현하지 못했습니다.
- 다른 기능부터 먼저 구현하고 오늘중으로 해결해볼게요

## 관련이슈

- #43 
